### PR TITLE
ci: build native iOS releases locally

### DIFF
--- a/.github/workflows/native-dev-build.yml
+++ b/.github/workflows/native-dev-build.yml
@@ -11,20 +11,35 @@ permissions:
 
 jobs:
   build:
-    name: EAS Build
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
+    name: Local iOS Development Build
+    runs-on: [self-hosted, macOS, ARM64, macos-tartelet]
+    timeout-minutes: 120
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: yarn
+
+      - name: Select Xcode
+        run: |
+          if [ -d /Applications/Xcode_26.4.1.app ]; then
+            XCODE_APP=/Applications/Xcode_26.4.1.app
+          elif [ -d /Applications/Xcode.app ]; then
+            XCODE_APP=/Applications/Xcode.app
+          else
+            echo "::error::Xcode is not installed on this runner."
+            ls -1 /Applications | grep -i Xcode || true
+            exit 1
+          fi
+
+          echo "DEVELOPER_DIR=$XCODE_APP/Contents/Developer" >> "$GITHUB_ENV"
+          xcodebuild -version
 
       - name: Setup Expo and EAS
         uses: expo/expo-github-action@v8
@@ -38,15 +53,23 @@ jobs:
           base64-encoded-secret: ${{ secrets.EXPO_IOS_ASC_API_KEY }}
           filename: "packages/app/asc_api_key.p8"
 
-      - name: Play Market Console Key file creation
-        uses: MobileDevOps/secret-to-file-action@v1.0.0
-        with:
-          base64-encoded-secret: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
-          filename: "packages/app/google-service-account.json"
-
       - name: Install dependencies
         run: yarn install
 
-      - name: Build on EAS
+      - name: Build iOS app locally
         working-directory: packages/app
-        run: eas build --platform all --non-interactive --no-wait --profile development
+        env:
+          EXPO_USE_PRECOMPILED_MODULES: "1"
+          RCT_USE_PREBUILT_RNCORE: "1"
+          RCT_USE_RN_DEP: "1"
+        run: |
+          mkdir -p ../../artifacts
+          eas build --platform ios --profile development --local --non-interactive --output ../../artifacts/suuudokuuu-development.ipa
+
+      - name: Upload iOS artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: suuudokuuu-development-ios
+          path: artifacts/suuudokuuu-development.ipa
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/native-publish.yml
+++ b/.github/workflows/native-publish.yml
@@ -11,20 +11,35 @@ permissions:
 
 jobs:
   build-and-publish:
-    name: Build & Publish to App Stores
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
+    name: Build & Submit iOS to App Store
+    runs-on: [self-hosted, macOS, ARM64, macos-tartelet]
+    timeout-minutes: 120
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22.x
           cache: yarn
+
+      - name: Select Xcode
+        run: |
+          if [ -d /Applications/Xcode_26.4.1.app ]; then
+            XCODE_APP=/Applications/Xcode_26.4.1.app
+          elif [ -d /Applications/Xcode.app ]; then
+            XCODE_APP=/Applications/Xcode.app
+          else
+            echo "::error::Xcode is not installed on this runner."
+            ls -1 /Applications | grep -i Xcode || true
+            exit 1
+          fi
+
+          echo "DEVELOPER_DIR=$XCODE_APP/Contents/Developer" >> "$GITHUB_ENV"
+          xcodebuild -version
 
       - name: Setup Expo and EAS
         uses: expo/expo-github-action@v8
@@ -38,15 +53,27 @@ jobs:
           base64-encoded-secret: ${{ secrets.EXPO_IOS_ASC_API_KEY }}
           filename: "packages/app/asc_api_key.p8"
 
-      - name: Play Market Console Key file creation
-        uses: MobileDevOps/secret-to-file-action@v1.0.0
-        with:
-          base64-encoded-secret: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
-          filename: "packages/app/google-service-account.json"
-
       - name: Install dependencies
         run: yarn install
 
-      - name: Build on EAS
+      - name: Build iOS app locally
         working-directory: packages/app
-        run: eas build --platform all --non-interactive --auto-submit --no-wait
+        env:
+          EXPO_USE_PRECOMPILED_MODULES: "1"
+          RCT_USE_PREBUILT_RNCORE: "1"
+          RCT_USE_RN_DEP: "1"
+        run: |
+          mkdir -p ../../artifacts
+          eas build --platform ios --profile production --local --non-interactive --output ../../artifacts/suuudokuuu-production.ipa
+
+      - name: Upload iOS artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: suuudokuuu-production-ios
+          path: artifacts/suuudokuuu-production.ipa
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Submit iOS app
+        working-directory: packages/app
+        run: eas submit --platform ios --profile production --path ../../artifacts/suuudokuuu-production.ipa --non-interactive


### PR DESCRIPTION
Root cause: suuudokuuu's manual native build workflows still ran hosted EAS builds via `eas build --platform all --no-wait` on GitHub-hosted Ubuntu. Those enqueue Expo-hosted builders and consume EAS build credits.\n\nChanges:\n- Move manual development and publish native workflows to the self-hosted macOS Tartelet runner.\n- Replace hosted all-platform EAS builds with local iOS IPA builds using `eas build --platform ios --local`.\n- Upload the generated IPA artifacts.\n- Submit iOS from the local production IPA instead of `eas build --auto-submit`.\n\nValidation:\n- Parsed both edited workflow YAML files with Ruby YAML.\n- Ran `git diff --check`.\n- Confirmed edited native workflows no longer contain hosted `eas build --platform all`, `--no-wait`, or `--auto-submit`.