### PR TITLE
docs(app): replace stale NativeWind styling docs with StyleSheet conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,7 +227,7 @@ After modifying user-facing text, run `yarn i18n:sync` and commit both file type
 
 | Package | Stack |
 |---------|-------|
-| **app** | Expo 54, React 19 + Compiler, Expo Router 6, Redux Toolkit, NativeWind 5, Lingui 5.7, Reanimated 4 |
+| **app** | Expo 54, React 19 + Compiler, Expo Router 6, Redux Toolkit, StyleSheet styling, Lingui 5.7, Reanimated 4 |
 | **generator** | Pure TypeScript, DLX solver, backtracking algorithm |
 | **encoder** | @thi.ng/bitstream, lz-string compression |
 | **Build** | Yarn 4.12 (PnP), Node >= 22, Lerna 8, TurboRepo 2, TypeScript 5.9, ESLint 9 |

--- a/packages/app/CLAUDE.md
+++ b/packages/app/CLAUDE.md
@@ -1,6 +1,6 @@
 # App Package (React Native)
 
-Main Sudoku game application built with Expo 54, React 19 + Compiler, Expo Router 6, Redux Toolkit, NativeWind 5, Reanimated 4, and Lingui 5.7.
+Main Sudoku game application built with Expo 54, React 19 + Compiler, Expo Router 6, Redux Toolkit, Reanimated 4, and Lingui 5.7. Styling uses React Native `StyleSheet.create`.
 
 ## Commands
 
@@ -141,7 +141,7 @@ export const MyComponent = (props: Props) => {
 ```typescript
 // Good - Destructure in body for many props
 export const MyComponent = (props: Props) => {
-    const { className, header, footer, children, ...rest } = props;
+    const { style, header, footer, children, ...rest } = props;
 };
 
 // Good - Destructure in signature for few props
@@ -160,27 +160,59 @@ const handleClose = () => void ref.current?.close();
 <Button onPress={() => void ref.current?.close()} />
 ```
 
-## Styling (NativeWind + CVA)
+## Styling (StyleSheet)
 
-### CVA for Variants
+### Styles in Sibling Files
 
-Always use `class-variance-authority` for components with style variants:
+Each component's styles live in a sibling `.styles.ts` file, exported as a single `StyleSheet.create` constant named `<ComponentName>Styles`:
 
 ```typescript
-import { cva } from 'class-variance-authority';
+// game-timer.styles.ts
+import { StyleSheet } from 'react-native';
 
-const buttonVariants = cva('flex-row items-center gap-x-xl justify-center border', {
-    variants: { variant: { primary: '...', secondary: '...' } },
-    defaultVariants: { variant: 'primary' }
+export const GameTimerStyles = StyleSheet.create({
+    text: {
+        fontWeight: 'bold'
+    }
 });
 ```
 
-### Utility Function
-
-Use `cn()` for combining classes:
 ```typescript
-import { cn } from '../../utils/cn/cn';
-className={cn('base-classes', classNameFromProps)}
+// game-timer.tsx
+import { GameTimerStyles as styles } from './game-timer.styles';
+
+<BlackText style={styles.text}>...</BlackText>
+```
+
+Shared styles live in `src/@generic/styles/` (e.g. `cell.styles.ts`).
+
+### Conditional and Dynamic Styles
+
+Use `cs()` from `@rnw-community/shared` for conditional styles, combined with dynamic values in a style array:
+
+```typescript
+import { cs } from '@rnw-community/shared';
+
+const textStyles = [
+    { color: getCellTextColor() },
+    cs(isActive, styles.textActive),
+    { fontSize: CellFontSizeConstant * fontSizeMultiplier }
+];
+
+<Reanimated.Text style={textStyles}>{text}</Reanimated.Text>
+```
+
+### Theme Colors
+
+Never hardcode colors - read them from `ThemeContext`:
+
+```typescript
+import { use } from 'react';
+import { ThemeContext } from '../../../theme/context/theme.context';
+
+const { theme } = use(ThemeContext);
+
+const color = theme.colors.cell.activeText;
 ```
 
 ## State Management (Redux Toolkit)


### PR DESCRIPTION
## Summary

The styling conventions in `packages/app/CLAUDE.md` described NativeWind 5 + CVA with `className`/`cn()`/`cva()` patterns, but the app doesn't use any of these: there are zero `className=` usages in `packages/app/src`, no nativewind/tailwind/class-variance-authority dependencies or configs, and 42 files use `StyleSheet.create`.

## Changes

- **CLAUDE.md**: tech-stack table now lists "StyleSheet styling" for the app package instead of "NativeWind 5"
- **packages/app/CLAUDE.md**:
  - Intro no longer mentions NativeWind 5, notes styling uses `StyleSheet.create`
  - Replaced the "Styling (NativeWind + CVA)" section with actual conventions: sibling `.styles.ts` files exported as `<ComponentName>Styles`, shared styles in `src/@generic/styles/`, conditional styles via `cs()` from `@rnw-community/shared` in style arrays, theme colors from `ThemeContext`
  - Props destructuring example uses `style` instead of the leftover `className`

Docs-only change, examples taken from real components (`game-timer`, `field-cell-text`).