### PR TITLE
ci: stop automatic EAS usage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,38 +90,3 @@ jobs:
           cp ../vercel.json .
           vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
           vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
-
-  eas-update:
-    name: EAS Update
-    needs: release
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - name: Check for EXPO_TOKEN
-        run: |
-          if [ -z "${{ secrets.EXPO_TOKEN }}" ]; then
-            echo "You must provide an EXPO_TOKEN secret linked to this project's Expo account in this repo's secrets. Learn more: https://docs.expo.dev/eas-update/github-actions"
-            exit 1
-          fi
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.x
-          cache: yarn
-
-      - name: Setup EAS
-        uses: expo/expo-github-action@v8
-        with:
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: Install dependencies
-        run: yarn install
-
-      - name: Publish update
-        working-directory: packages/app
-        run: eas update --channel production --auto

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -58,146 +58,8 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
 
-  eas-deploy:
-    name: EAS Deploy
-    needs: code-quality
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      pull-requests: write
-      deployments: write
-      issues: write
-    outputs:
-      deployment_url: ${{ steps.deploy-web.outputs.deployment_url }}
-      projectId: ${{ steps.create-preview.outputs.projectId }}
-      iosGroupId: ${{ steps.create-preview.outputs.iosGroupId }}
-      androidGroupId: ${{ steps.create-preview.outputs.androidGroupId }}
-    steps:
-      - name: Check for EXPO_TOKEN
-        run: |
-          if [ -z "${{ secrets.EXPO_TOKEN }}" ]; then
-            echo "You must provide an EXPO_TOKEN secret linked to this project."
-            echo "Learn more: https://docs.expo.dev/eas/github-actions"
-            exit 1
-          fi
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.x
-          cache: yarn
-
-      - name: Setup EAS
-        uses: expo/expo-github-action@v8
-        with:
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: Install dependencies
-        run: yarn install
-
-      - name: Create preview
-        id: create-preview
-        uses: expo/expo-github-action/preview@v8
-        with:
-          command: eas update --channel development --auto
-          working-directory: packages/app
-
-      - name: Build web app
-        working-directory: packages/app
-        run: npx expo export --platform web
-
-      - name: Deploy web app
-        id: deploy-web
-        working-directory: packages/app
-        run: |
-          result="$(eas deploy --non-interactive --json)"
-          echo "$result"
-
-          # Extract the URL from the deployment result
-          url=$(echo "$result" | jq -r '.url // empty')
-          if [ -n "$url" ]; then
-            echo "deployment_url=$url" >> $GITHUB_OUTPUT
-            echo "## 🚀 Web App Deployment" >> $GITHUB_STEP_SUMMARY
-            echo "Your PR has been deployed and is available at: [$url]($url)" \
-              >> $GITHUB_STEP_SUMMARY
-          fi
-
-      - name: Create deployment environment
-        if: steps.deploy-web.outputs.deployment_url
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const deploymentUrl = '${{ steps.deploy-web.outputs.deployment_url }}';
-
-            // Create deployment
-            const deployment = await github.rest.repos.createDeployment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: context.payload.pull_request.head.sha,
-              environment: 'preview',
-              description: 'PR Preview Deployment',
-              auto_merge: false,
-              required_contexts: []
-            });
-
-            // Create deployment status
-            await github.rest.repos.createDeploymentStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              deployment_id: deployment.data.id,
-              state: 'success',
-              environment_url: deploymentUrl,
-              description: 'Web app deployed successfully'
-            });
-
-      - name: Comment deployment URL on PR
-        if: steps.deploy-web.outputs.deployment_url
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const deploymentUrl = '${{ steps.deploy-web.outputs.deployment_url }}';
-            const prNumber = context.payload.pull_request.number;
-
-            const comments = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber
-            });
-
-            const existingComment = comments.data.find(comment =>
-              comment.user.login === 'github-actions[bot]' &&
-              comment.body.includes('🚀 Preview Deployment')
-            );
-
-            const commentBody = '## 🚀 Preview Deployment\n\n' +
-              'Your PR has been deployed! You can test the changes at:\n\n' +
-              '🌐 **[Open Preview App](' + deploymentUrl + ')**\n\n' +
-              'This deployment will be automatically updated with new commits.';
-
-            if (existingComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existingComment.id,
-                body: commentBody
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                body: commentBody
-              });
-            }
-
-
   e2e-ios:
-    needs: [code-quality, eas-deploy]
+    needs: code-quality
     name: E2E Tests on iOS
     if: ${{ !github.event.pull_request.draft }}
     runs-on: [self-hosted, macOS, ARM64, macos-tartelet]
@@ -286,7 +148,7 @@ jobs:
             tests/app-tests/*.mp4
 
   e2e-android:
-    needs: [ code-quality, eas-deploy ]
+    needs: code-quality
     name: E2E Tests on Android
     if: ${{ false }}
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -62,7 +62,7 @@ jobs:
     needs: code-quality
     name: E2E Tests on iOS
     if: ${{ !github.event.pull_request.draft }}
-    runs-on: [self-hosted, macOS, ARM64, macos-tartelet]
+    runs-on: macos-latest
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- remove the automatic EAS Update job from the main deploy workflow
- remove the PR EAS Deploy preview job that ran eas update/eas deploy on GitHub-hosted Ubuntu
- keep PR iOS E2E dependent only on code quality so the local EAS build stays on the self-hosted Mac Tartelet runner

## Why
The Expo billing alert pointed at EAS usage still being triggered by Sudoku CI. The native iOS builds are already local Mac-runner builds, but automatic update/deploy jobs still talked to EAS on GitHub-hosted runners.

## Validation
- parsed affected workflow YAML with Ruby Psych
- searched remaining workflows for eas update/eas deploy/preview usage
- verified current runner health separately: 0 failures, 0 warnings