### PR TITLE
ci: restore local macOS runner profiles

### DIFF
--- a/.github/workflows/ios-maestro.yml
+++ b/.github/workflows/ios-maestro.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   build:
     name: Build embedded iOS E2E app
-    runs-on: macos-26
+    runs-on: [self-hosted, macOS, ARM64, macos-builder]
     timeout-minutes: 90
     env:
       APP_VARIANT: e2e
@@ -210,7 +210,7 @@ jobs:
   test:
     needs: build
     name: Maestro shard ${{ matrix.shard-number }}/2
-    runs-on: macos-26
+    runs-on: [self-hosted, macOS, ARM64, macos-maestro]
     timeout-minutes: 45
     strategy:
       fail-fast: false

--- a/.github/workflows/native-dev-build.yml
+++ b/.github/workflows/native-dev-build.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   build:
     name: Local iOS Development Build
-    runs-on: macos-latest
+    runs-on: [self-hosted, macOS, ARM64, macos-builder]
     timeout-minutes: 120
     steps:
       - name: Checkout repository

--- a/.github/workflows/native-publish.yml
+++ b/.github/workflows/native-publish.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   build-and-publish:
     name: Build & Submit iOS to App Store
-    runs-on: macos-latest
+    runs-on: [self-hosted, macOS, ARM64, macos-builder]
     timeout-minutes: 120
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## What changed

- route the fingerprinted iOS builder back to `macos-builder`
- route the two Maestro shards back to `macos-maestro`

## Why

PR #187 was based on older workflow routing and changed both jobs to GitHub-hosted `macos-26`, displacing the local builder/two-VM Maestro standard merged in PR #201. The local fleet already provides Xcode 26.4.1 and validated two-shard parallel execution.

## Validation

- workflow YAML parsed successfully
- `git diff --check` passed
- change is limited to two `runs-on` selectors