### PR TITLE
ci: tier Linux runner workloads

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,7 +20,7 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
-    runs-on: [self-hosted, linux-burst]
+    runs-on: [self-hosted, linux-burst, linux-small]
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,7 +20,7 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
-    runs-on: [self-hosted, linux-burst, linux-small]
+    runs-on: [self-hosted, linux-burst, linux-medium]
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,7 +20,7 @@ jobs:
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
-    runs-on: [self-hosted, linux-burst, linux-medium]
+    runs-on: [self-hosted, linux-tiered, linux-medium]
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: [self-hosted, linux-burst, linux-medium]
+    runs-on: [self-hosted, linux-tiered, linux-medium]
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: [self-hosted, linux-burst, linux-small]
+    runs-on: [self-hosted, linux-burst, linux-medium]
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,7 +17,7 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: [self-hosted, linux-burst]
+    runs-on: [self-hosted, linux-burst, linux-small]
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/ios-maestro.yml
+++ b/.github/workflows/ios-maestro.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Generate native project
         if: steps.native-plan.outputs.required == 'true'
         working-directory: packages/app
-        run: npx expo prebuild -p ios --clean
+        run: npx expo prebuild -p ios --clean --no-install
 
       - name: Install pods
         if: steps.native-plan.outputs.required == 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   release:
     name: Publish a release
-    runs-on: [self-hosted, linux-burst]
+    runs-on: [self-hosted, linux-burst, linux-medium]
     timeout-minutes: 20
     steps:
       - name: Checkout repository
@@ -80,7 +80,7 @@ jobs:
   web-deploy:
     name: Vercel deploy Web
     needs: release
-    runs-on: [self-hosted, linux-burst]
+    runs-on: [self-hosted, linux-burst, linux-medium]
     timeout-minutes: 20
     steps:
       - name: Checkout repository

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   release:
     name: Publish a release
-    runs-on: [self-hosted, linux-burst, linux-medium]
+    runs-on: [self-hosted, linux-tiered, linux-medium]
     timeout-minutes: 20
     steps:
       - name: Checkout repository
@@ -80,7 +80,7 @@ jobs:
   web-deploy:
     name: Vercel deploy Web
     needs: release
-    runs-on: [self-hosted, linux-burst, linux-medium]
+    runs-on: [self-hosted, linux-tiered, linux-medium]
     timeout-minutes: 20
     steps:
       - name: Checkout repository

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   code-quality:
     name: Code quality checks
-    runs-on: [self-hosted, linux-burst, linux-medium]
+    runs-on: [self-hosted, linux-tiered, linux-medium]
     timeout-minutes: 20
     permissions:
       pull-requests: write
@@ -74,7 +74,7 @@ jobs:
     if: ${{ always() }}
     needs: [code-quality, ios-maestro]
     name: Required CI
-    runs-on: [self-hosted, linux-burst, linux-small]
+    runs-on: [self-hosted, linux-tiered, linux-small]
     timeout-minutes: 5
     steps:
       - name: Verify required jobs

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -74,7 +74,7 @@ jobs:
     if: ${{ always() }}
     needs: [code-quality, ios-maestro]
     name: Required CI
-    runs-on: [self-hosted, linux-tiered, linux-small]
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Verify required jobs

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   code-quality:
     name: Code quality checks
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux-burst, linux-medium]
     timeout-minutes: 20
     permissions:
       pull-requests: write
@@ -74,7 +74,7 @@ jobs:
     if: ${{ always() }}
     needs: [code-quality, ios-maestro]
     name: Required CI
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux-burst, linux-small]
     timeout-minutes: 5
     steps:
       - name: Verify required jobs
@@ -86,109 +86,3 @@ jobs:
             echo "Required jobs did not pass: code-quality=$CODE_QUALITY_RESULT, ios-maestro=$IOS_MAESTRO_RESULT"
             exit 1
           fi
-
-  e2e-android:
-    needs: code-quality
-    name: E2E Tests on Android
-    if: ${{ false }}
-    runs-on: [self-hosted, linux-burst]
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Enable KVM group perms
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 22.x
-          cache: yarn
-
-      - name: Setup EAS
-        uses: expo/expo-github-action@v8
-        with:
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: Install dependencies
-        run: |
-          yarn install
-
-      - name: Expo Prebuild
-        working-directory: packages/app
-        run: npx expo prebuild -p android --clean
-
-      - name: Cache Gradle
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('packages/app/android/**/*.gradle*', 'packages/app/android/gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-gradle-
-
-      - name: AVD cache
-        uses: actions/cache@v4
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-34
-
-      - name: Build app
-        working-directory: packages/app
-        run: |
-          eas build --profile=e2e --platform android --non-interactive --local --output app.android.apk
-
-      - name: Install Maestro
-        run: |
-          export MAESTRO_VERSION
-          curl -fsSL "https://get.maestro.mobile.dev" | bash
-          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
-
-      - name: Сreate AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 34
-          target: aosp_atd
-          channel: canary
-          arch: x86_64
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
-          script: echo "Generated AVD snapshot for caching."
-
-      - name: Start emulator and run Maestro tests
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 34
-          target: aosp_atd
-          channel: canary
-          arch: x86_64
-          force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          working-directory: tests/app-tests
-          script: |
-            cd ../../packages/app && eas build:run --platform android --path app.android.apk
-            cd ../../tests/app-tests
-            maestro_status=0
-            maestro test . -e APP_ID=com.vitalyiegorov.suuudokuuu.preview --config config.yaml --format junit --output ./report.xml --debug-output ./ || maestro_status=$?
-            killall -INT crashpad_handler || true
-            exit "$maestro_status"
-
-      - name: Upload Maestro artifacts (report, logs, videos, screenshots)
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: maestro-android-artifacts
-          include-hidden-files: true
-          path: |
-            tests/app-tests/.maestro/**
-            tests/app-tests/*.mp4


### PR DESCRIPTION
## What changed

- route the required-status gate to `linux-small` (1 CPU / 2 GB)
- route Claude, quality, release, and web deployment to `linux-medium` (2 CPU / 4 GB)
- remove the permanently disabled Android Maestro workflow
- keep CodeQL on x64 GitHub Linux because the local fleet is ARM64
- isolate new `linux-tiered` routing from legacy `linux-burst` jobs so subset label matching cannot bypass sizing
- use Expo prebuild `--no-install` so the explicit cached CocoaPods step is the only pod installation on native cache misses

## Why

The jobs now request resources according to their actual workload instead of sharing one repository-wide VM size. This also allows safe Suuudokuuu concurrency under the fleet's aggregate CPU and memory budget.

## Validation

- all workflow YAML parsed successfully
- `git diff --check`
- tier-aware runner-manager smoke suite: 37 assertions
