### PR TITLE
ci: harden native build and release workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: main
           persist-credentials: false
           fetch-depth: 0
 
@@ -47,8 +48,8 @@ jobs:
           git config user.email "vitalyiegorov@gmail.com"
           git remote rm origin
           git remote add origin https://vitalyiegorov:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          git fetch
-          git branch --set-upstream-to=origin/main main
+          git fetch origin main --tags
+          git checkout -B main origin/main
 
       - name: Install dependencies
         env:
@@ -71,11 +72,6 @@ jobs:
 
       - name: Publish a release
         run: yarn release
-
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.PUSH_TO_PROTECTED_TOKEN }}
 
   web-deploy:
     name: Vercel deploy Web

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,9 +47,21 @@ jobs:
           git config user.name "Vitalii Yehorov"
           git config user.email "vitalyiegorov@gmail.com"
           git remote rm origin
-          git remote add origin https://vitalyiegorov:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          git fetch origin main --tags
+          git remote add origin "https://vitalyiegorov:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git fetch --force --prune --tags origin +refs/heads/main:refs/remotes/origin/main
           git checkout -B main origin/main
+
+      - name: Verify release source
+        run: |
+          if [ "$(git branch --show-current)" != "main" ]; then
+            echo "Release must run from main."
+            exit 1
+          fi
+
+          if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
+            echo "Release checkout does not match origin/main."
+            exit 1
+          fi
 
       - name: Install dependencies
         env:

--- a/.github/workflows/native-dev-build.yml
+++ b/.github/workflows/native-dev-build.yml
@@ -1,12 +1,7 @@
 name: Build Development build
 env:
-  EXPO_APPLE_TEAM_ID: 3R8589YV24
-  EXPO_APPLE_TEAM_TYPE: INDIVIDUAL
   EXPO_NO_TELEMETRY: '1'
   EAS_CLI_VERSION: '20.5.1'
-  EXPO_USE_PRECOMPILED_MODULES: '1'
-  RCT_USE_PREBUILT_RNCORE: '1'
-  RCT_USE_RN_DEP: '1'
   TURBO_TEAM: vitalyiegorov
   TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
@@ -17,10 +12,16 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  ios-development-build:
     name: Local iOS Development Build
     runs-on: [self-hosted, macOS, ARM64, macos-builder]
     timeout-minutes: 120
+    env:
+      EXPO_APPLE_TEAM_ID: 3R8589YV24
+      EXPO_APPLE_TEAM_TYPE: INDIVIDUAL
+      EXPO_USE_PRECOMPILED_MODULES: '1'
+      RCT_USE_PREBUILT_RNCORE: '1'
+      RCT_USE_RN_DEP: '1'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -35,9 +36,11 @@ jobs:
 
       - name: Configure macOS toolchain
         run: |
-          echo "$HOME/.rbenv/shims" >> "$GITHUB_PATH"
-          echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
-          echo "/opt/homebrew/sbin" >> "$GITHUB_PATH"
+          {
+            echo "$HOME/.rbenv/shims"
+            echo "/opt/homebrew/bin"
+            echo "/opt/homebrew/sbin"
+          } >> "$GITHUB_PATH"
 
           export PATH="$HOME/.rbenv/shims:/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
           pod --version
@@ -65,7 +68,7 @@ jobs:
             XCODE_APP=/Applications/Xcode.app
           else
             echo "::error::Xcode is not installed on this runner."
-            ls -1 /Applications | grep -i Xcode || true
+            find /Applications -maxdepth 1 -iname '*xcode*' -print
             exit 1
           fi
 
@@ -108,3 +111,67 @@ jobs:
       - name: Remove App Store Connect key
         if: always()
         run: rm -f packages/app/asc_api_key.p8
+
+  android-development-build:
+    name: Local Android Development Build
+    runs-on: [self-hosted, macOS, ARM64, macos-builder]
+    timeout-minutes: 120
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: main
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: yarn
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Configure Android toolchain
+        run: |
+          test -d "$ANDROID_HOME" || {
+            echo "::error::ANDROID_HOME does not point to an installed Android SDK."
+            exit 1
+          }
+
+          java -version
+          "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --version
+
+      - name: Verify build credentials
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          test -n "$EXPO_TOKEN" || {
+            echo "::error::EXPO_TOKEN is not configured."
+            exit 1
+          }
+
+      - name: Setup Expo and EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: ${{ env.EAS_CLI_VERSION }}
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build Android app locally
+        working-directory: packages/app
+        run: |
+          mkdir -p ../../artifacts
+          eas build --platform android --profile development --local --non-interactive --output ../../artifacts/suuudokuuu-development.apk
+
+      - name: Upload Android artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: suuudokuuu-development-android
+          path: artifacts/suuudokuuu-development.apk
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/native-publish.yml
+++ b/.github/workflows/native-publish.yml
@@ -1,12 +1,7 @@
 name: Build and Publish to Stores
 env:
-  EXPO_APPLE_TEAM_ID: 3R8589YV24
-  EXPO_APPLE_TEAM_TYPE: INDIVIDUAL
   EXPO_NO_TELEMETRY: '1'
   EAS_CLI_VERSION: '20.5.1'
-  EXPO_USE_PRECOMPILED_MODULES: '1'
-  RCT_USE_PREBUILT_RNCORE: '1'
-  RCT_USE_RN_DEP: '1'
   TURBO_TEAM: vitalyiegorov
   TURBO_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
@@ -21,10 +16,16 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build-and-publish:
+  ios-build-and-publish:
     name: Build & Submit iOS to App Store
     runs-on: [self-hosted, macOS, ARM64, macos-builder]
     timeout-minutes: 120
+    env:
+      EXPO_APPLE_TEAM_ID: 3R8589YV24
+      EXPO_APPLE_TEAM_TYPE: INDIVIDUAL
+      EXPO_USE_PRECOMPILED_MODULES: '1'
+      RCT_USE_PREBUILT_RNCORE: '1'
+      RCT_USE_RN_DEP: '1'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -39,9 +40,11 @@ jobs:
 
       - name: Configure macOS toolchain
         run: |
-          echo "$HOME/.rbenv/shims" >> "$GITHUB_PATH"
-          echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
-          echo "/opt/homebrew/sbin" >> "$GITHUB_PATH"
+          {
+            echo "$HOME/.rbenv/shims"
+            echo "/opt/homebrew/bin"
+            echo "/opt/homebrew/sbin"
+          } >> "$GITHUB_PATH"
 
           export PATH="$HOME/.rbenv/shims:/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
           pod --version
@@ -69,7 +72,7 @@ jobs:
             XCODE_APP=/Applications/Xcode.app
           else
             echo "::error::Xcode is not installed on this runner."
-            ls -1 /Applications | grep -i Xcode || true
+            find /Applications -maxdepth 1 -iname '*xcode*' -print
             exit 1
           fi
 
@@ -116,3 +119,86 @@ jobs:
       - name: Remove App Store Connect key
         if: always()
         run: rm -f packages/app/asc_api_key.p8
+
+  android-build-and-publish:
+    name: Build & Submit Android to Google Play
+    runs-on: [self-hosted, macOS, ARM64, macos-builder]
+    timeout-minutes: 120
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: main
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: yarn
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Configure Android toolchain
+        run: |
+          test -d "$ANDROID_HOME" || {
+            echo "::error::ANDROID_HOME does not point to an installed Android SDK."
+            exit 1
+          }
+
+          java -version
+          "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --version
+
+      - name: Verify release credentials
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
+        run: |
+          test -n "$EXPO_TOKEN" || {
+            echo "::error::EXPO_TOKEN is not configured."
+            exit 1
+          }
+          test -n "$GOOGLE_SERVICE_ACCOUNT_JSON" || {
+            echo "::error::GOOGLE_SERVICE_ACCOUNT_JSON is not configured."
+            exit 1
+          }
+
+      - name: Setup Expo and EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: ${{ env.EAS_CLI_VERSION }}
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Google Play service account file creation
+        uses: MobileDevOps/secret-to-file-action@v1.0.0
+        with:
+          base64-encoded-secret: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
+          filename: 'packages/app/google-service-account.json'
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build Android app locally
+        working-directory: packages/app
+        run: |
+          mkdir -p ../../artifacts
+          eas build --platform android --profile production --local --non-interactive --output ../../artifacts/suuudokuuu-production.aab
+
+      - name: Upload Android artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: suuudokuuu-production-android
+          path: artifacts/suuudokuuu-production.aab
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Submit Android app
+        working-directory: packages/app
+        run: eas submit --platform android --profile production --path ../../artifacts/suuudokuuu-production.aab --non-interactive
+
+      - name: Remove Google Play service account key
+        if: always()
+        run: rm -f packages/app/google-service-account.json

--- a/tests/app-tests/flows/06.resume-game.flow.yaml
+++ b/tests/app-tests/flows/06.resume-game.flow.yaml
@@ -9,7 +9,6 @@ appId: ${APP_ID}
 - copyTextFrom:
     id: 'GameScreenSelectors.Time'
 - evalScript: ${output.firstPausedSeconds = Number(maestro.copiedText.split(':')[0]) * 60 + Number(maestro.copiedText.split(':')[1])}
-- evalScript: ${output.firstPauseWallStartedAt = Date.now()}
 - runFlow: subflows/game/open-settings-from-game.flow.yaml
 - runFlow:
     file: subflows/shared/wait-observation-window.flow.yaml
@@ -26,15 +25,13 @@ appId: ${APP_ID}
 - copyTextFrom:
     id: 'GameScreenSelectors.Time'
 - evalScript: ${output.firstReturnedSeconds = Number(maestro.copiedText.split(':')[0]) * 60 + Number(maestro.copiedText.split(':')[1])}
-- evalScript: ${output.firstPauseWallElapsedSeconds = (Date.now() - output.firstPauseWallStartedAt) / 1000}
 - assertTrue:
-    condition: ${output.firstPauseWallElapsedSeconds - (output.firstReturnedSeconds - output.firstPausedSeconds) >= 3}
+    condition: ${output.firstReturnedSeconds <= output.firstPausedSeconds + 2}
     label: Timer stays paused while settings are open
 - runFlow: subflows/game/assert-timer-advances.flow.yaml
 - copyTextFrom:
     id: 'GameScreenSelectors.Time'
 - evalScript: ${output.secondPausedSeconds = Number(maestro.copiedText.split(':')[0]) * 60 + Number(maestro.copiedText.split(':')[1])}
-- evalScript: ${output.secondPauseWallStartedAt = Date.now()}
 - runFlow: subflows/game/open-settings-from-game.flow.yaml
 - runFlow:
     file: subflows/shared/wait-observation-window.flow.yaml
@@ -51,9 +48,8 @@ appId: ${APP_ID}
 - copyTextFrom:
     id: 'GameScreenSelectors.Time'
 - evalScript: ${output.secondReturnedSeconds = Number(maestro.copiedText.split(':')[0]) * 60 + Number(maestro.copiedText.split(':')[1])}
-- evalScript: ${output.secondPauseWallElapsedSeconds = (Date.now() - output.secondPauseWallStartedAt) / 1000}
 - assertTrue:
-    condition: ${output.secondPauseWallElapsedSeconds - (output.secondReturnedSeconds - output.secondPausedSeconds) >= 3}
+    condition: ${output.secondReturnedSeconds <= output.secondPausedSeconds + 2}
     label: Timer stays paused during a second settings visit
 - runFlow: subflows/game/assert-timer-advances.flow.yaml
 - runFlow: subflows/game/open-settings-from-game.flow.yaml

--- a/tests/app-tests/flows/06.resume-game.flow.yaml
+++ b/tests/app-tests/flows/06.resume-game.flow.yaml
@@ -9,6 +9,7 @@ appId: ${APP_ID}
 - copyTextFrom:
     id: 'GameScreenSelectors.Time'
 - evalScript: ${output.firstPausedSeconds = Number(maestro.copiedText.split(':')[0]) * 60 + Number(maestro.copiedText.split(':')[1])}
+- evalScript: ${output.firstPauseWallStartedAt = Date.now()}
 - runFlow: subflows/game/open-settings-from-game.flow.yaml
 - runFlow:
     file: subflows/shared/wait-observation-window.flow.yaml
@@ -25,13 +26,15 @@ appId: ${APP_ID}
 - copyTextFrom:
     id: 'GameScreenSelectors.Time'
 - evalScript: ${output.firstReturnedSeconds = Number(maestro.copiedText.split(':')[0]) * 60 + Number(maestro.copiedText.split(':')[1])}
+- evalScript: ${output.firstPauseWallElapsedSeconds = (Date.now() - output.firstPauseWallStartedAt) / 1000}
 - assertTrue:
-    condition: ${output.firstReturnedSeconds <= output.firstPausedSeconds + 2}
+    condition: ${output.firstPauseWallElapsedSeconds - (output.firstReturnedSeconds - output.firstPausedSeconds) >= 3}
     label: Timer stays paused while settings are open
 - runFlow: subflows/game/assert-timer-advances.flow.yaml
 - copyTextFrom:
     id: 'GameScreenSelectors.Time'
 - evalScript: ${output.secondPausedSeconds = Number(maestro.copiedText.split(':')[0]) * 60 + Number(maestro.copiedText.split(':')[1])}
+- evalScript: ${output.secondPauseWallStartedAt = Date.now()}
 - runFlow: subflows/game/open-settings-from-game.flow.yaml
 - runFlow:
     file: subflows/shared/wait-observation-window.flow.yaml
@@ -48,8 +51,9 @@ appId: ${APP_ID}
 - copyTextFrom:
     id: 'GameScreenSelectors.Time'
 - evalScript: ${output.secondReturnedSeconds = Number(maestro.copiedText.split(':')[0]) * 60 + Number(maestro.copiedText.split(':')[1])}
+- evalScript: ${output.secondPauseWallElapsedSeconds = (Date.now() - output.secondPauseWallStartedAt) / 1000}
 - assertTrue:
-    condition: ${output.secondReturnedSeconds <= output.secondPausedSeconds + 2}
+    condition: ${output.secondPauseWallElapsedSeconds - (output.secondReturnedSeconds - output.secondPausedSeconds) >= 3}
     label: Timer stays paused during a second settings visit
 - runFlow: subflows/game/assert-timer-advances.flow.yaml
 - runFlow: subflows/game/open-settings-from-game.flow.yaml


### PR DESCRIPTION
## Summary

- force production releases onto the current `origin/main` before Lerna runs
- remove the redundant unconditional push after publishing
- restore Android as an independent local build in both production and development workflows
- build all IPA, AAB, and APK artifacts locally on the self-hosted macOS builders
- submit only the local production IPA and AAB through EAS
- clean up temporary App Store and Google Play credentials

## Root causes

Production deploy run `29195055734` waited in the runner queue while `main` advanced. Lerna correctly stopped with `EBEHIND`, then the redundant push action failed non-fast-forward.

Store run `29196966717` never reached Xcode. Its Apple distribution certificate and provisioning profile had expired on January 6, 2026. Those credentials have now been renewed through January 6, 2027.

Android disappeared from both native workflows when PR #188 replaced the previous EAS cloud `--platform all` builds with iOS-only local builds. The Android package, EAS keystore, Google Play service-account secret, and submit profile still exist.

## Release model

- iOS and Android are separate jobs with no dependency edge
- production and development both run `eas build --local` on `macos-builder`
- no EAS cloud builders, `--auto-submit`, or `--no-wait`
- production sends completed local artifacts to EAS Submit
- development uploads the local IPA and APK as workflow artifacts without store submission

## Validation

- `yarn format && yarn ts && yarn lint && yarn deadcode && yarn cpd`
- `actionlint` for all three changed workflows, with custom runner labels ignored
- Ruby YAML parsing for all three changed workflows
- local-only Android production and development workflow contract checks
- `git diff --check`
