### PR TITLE
ci: provision Android SDK for local builds

### DIFF
--- a/.github/workflows/native-dev-build.yml
+++ b/.github/workflows/native-dev-build.yml
@@ -134,6 +134,11 @@ jobs:
           distribution: temurin
           java-version: '17'
 
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v4
+        with:
+          packages: 'platform-tools platforms;android-36 build-tools;36.0.0 ndk;27.1.12297006'
+
       - name: Configure Android toolchain
         run: |
           test -d "$ANDROID_HOME" || {
@@ -142,7 +147,7 @@ jobs:
           }
 
           java -version
-          "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --version
+          sdkmanager --version
 
       - name: Verify build credentials
         env:

--- a/.github/workflows/native-publish.yml
+++ b/.github/workflows/native-publish.yml
@@ -142,6 +142,11 @@ jobs:
           distribution: temurin
           java-version: '17'
 
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v4
+        with:
+          packages: 'platform-tools platforms;android-36 build-tools;36.0.0 ndk;27.1.12297006'
+
       - name: Configure Android toolchain
         run: |
           test -d "$ANDROID_HOME" || {
@@ -150,7 +155,7 @@ jobs:
           }
 
           java -version
-          "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --version
+          sdkmanager --version
 
       - name: Verify release credentials
         env:


### PR DESCRIPTION
## Summary
- provision the Android SDK on ephemeral macOS builders instead of assuming ANDROID_HOME exists
- install the exact React Native 0.86 Android platform, build-tools, and NDK versions
- validate sdkmanager from the PATH exported by the setup action in development and store workflows

## Root cause
Development run 29315469950 failed before EAS because the managed macOS runner had no Android SDK or ANDROID_HOME. The workflow inherited an assumption from the developer machine that does not hold for ephemeral runners.

## Validation
- actionlint for both workflows
- Ruby YAML parse for both workflows
- yarn format
- yarn ts
- yarn lint
- yarn deadcode
- yarn cpd