### PR TITLE
test: restore wall-time pause measurement

### DIFF
--- a/tests/app-tests/flows/06.resume-game.flow.yaml
+++ b/tests/app-tests/flows/06.resume-game.flow.yaml
@@ -9,6 +9,7 @@ appId: ${APP_ID}
 - copyTextFrom:
     id: 'GameScreenSelectors.Time'
 - evalScript: ${output.firstPausedSeconds = Number(maestro.copiedText.split(':')[0]) * 60 + Number(maestro.copiedText.split(':')[1])}
+- evalScript: ${output.firstPauseWallStartedAt = Date.now()}
 - runFlow: subflows/game/open-settings-from-game.flow.yaml
 - runFlow:
     file: subflows/shared/wait-observation-window.flow.yaml
@@ -25,13 +26,15 @@ appId: ${APP_ID}
 - copyTextFrom:
     id: 'GameScreenSelectors.Time'
 - evalScript: ${output.firstReturnedSeconds = Number(maestro.copiedText.split(':')[0]) * 60 + Number(maestro.copiedText.split(':')[1])}
+- evalScript: ${output.firstPauseWallElapsedSeconds = (Date.now() - output.firstPauseWallStartedAt) / 1000}
 - assertTrue:
-    condition: ${output.firstReturnedSeconds <= output.firstPausedSeconds + 2}
+    condition: ${output.firstPauseWallElapsedSeconds - (output.firstReturnedSeconds - output.firstPausedSeconds) >= 3}
     label: Timer stays paused while settings are open
 - runFlow: subflows/game/assert-timer-advances.flow.yaml
 - copyTextFrom:
     id: 'GameScreenSelectors.Time'
 - evalScript: ${output.secondPausedSeconds = Number(maestro.copiedText.split(':')[0]) * 60 + Number(maestro.copiedText.split(':')[1])}
+- evalScript: ${output.secondPauseWallStartedAt = Date.now()}
 - runFlow: subflows/game/open-settings-from-game.flow.yaml
 - runFlow:
     file: subflows/shared/wait-observation-window.flow.yaml
@@ -48,8 +51,9 @@ appId: ${APP_ID}
 - copyTextFrom:
     id: 'GameScreenSelectors.Time'
 - evalScript: ${output.secondReturnedSeconds = Number(maestro.copiedText.split(':')[0]) * 60 + Number(maestro.copiedText.split(':')[1])}
+- evalScript: ${output.secondPauseWallElapsedSeconds = (Date.now() - output.secondPauseWallStartedAt) / 1000}
 - assertTrue:
-    condition: ${output.secondReturnedSeconds <= output.secondPausedSeconds + 2}
+    condition: ${output.secondPauseWallElapsedSeconds - (output.secondReturnedSeconds - output.secondPausedSeconds) >= 3}
     label: Timer stays paused during a second settings visit
 - runFlow: subflows/game/assert-timer-advances.flow.yaml
 - runFlow: subflows/game/open-settings-from-game.flow.yaml


### PR DESCRIPTION
## Summary
- restore the proven wall-time measurement for both settings pause visits
- measure observed pause duration instead of assuming navigation completes within two seconds

## Red evidence
- PR211 run 29320203335, shard 2 job 87072762624
- `06.resume-game` failed while the app remained healthy because commit a39e2330 reverted the wall-time assertion to a brittle absolute timer delta

## Validation
- Ruby YAML parse
- format
- build
- TypeScript
- lint
- deadcode
- CPD: 0 clones
- diff check