### PR TITLE
ci(app): trim store Android build to shipping ABIs and preinstall its NDKs

### DIFF
--- a/.github/workflows/native-publish.yml
+++ b/.github/workflows/native-publish.yml
@@ -145,7 +145,7 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v4
         with:
-          packages: 'platform-tools platforms;android-36 build-tools;36.0.0 ndk;27.1.12297006'
+          packages: 'platform-tools platforms;android-36 build-tools;36.0.0 ndk;27.1.12297006 ndk;27.0.12077973 cmake;3.22.1'
 
       - name: Configure Android toolchain
         run: |
@@ -153,6 +153,12 @@ jobs:
             echo "::error::ANDROID_HOME does not point to an installed Android SDK."
             exit 1
           }
+
+          for ndk_version in 27.1.12297006 27.0.12077973; do
+            test -d "$ANDROID_HOME/ndk/$ndk_version" || {
+              echo "::warning::NDK $ndk_version is not installed; Gradle will download it mid-build."
+            }
+          done
 
           java -version
           sdkmanager --version
@@ -191,6 +197,18 @@ jobs:
         run: |
           mkdir -p ../../artifacts
           eas build --platform android --profile production --local --non-interactive --output ../../artifacts/suuudokuuu-production.aab
+
+      - name: Verify packaged Android ABIs
+        run: |
+          aab=artifacts/suuudokuuu-production.aab
+          entries=$(unzip -Z1 "$aab" 'base/lib/*/*' || true)
+          abis=$(printf '%s\n' "$entries" | cut -d/ -f3 | sort -u | grep -v '^$' || true)
+          printf 'Packaged ABIs:\n%s\n' "$abis"
+
+          printf '%s\n' "$abis" | grep -qx arm64-v8a || {
+            echo "::error::arm64-v8a is missing from the bundle; Google Play requires a 64-bit ABI."
+            exit 1
+          }
 
       - name: Upload Android artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/native-publish.yml
+++ b/.github/workflows/native-publish.yml
@@ -120,8 +120,60 @@ jobs:
         if: always()
         run: rm -f packages/app/asc_api_key.p8
 
+  android-release-lint:
+    name: Android release lint gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: main
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: yarn
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v4
+        with:
+          packages: 'platform-tools platforms;android-36 build-tools;36.0.0'
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Generate Android project
+        working-directory: packages/app
+        env:
+          APP_VARIANT: production
+        run: ../../node_modules/.bin/expo prebuild --platform android --no-install --clean
+
+      - name: Run release lint
+        working-directory: packages/app/android
+        run: ./gradlew :app:lintVitalRelease -PreactNativeArchitectures=arm64-v8a --no-daemon
+
+      - name: Upload lint report
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: suuudokuuu-production-android-lint
+          path: |
+            packages/app/android/app/build/reports/lint-results-*.html
+            packages/app/android/app/build/reports/lint-results-*.xml
+          if-no-files-found: ignore
+          retention-days: 14
+
   android-build-and-publish:
     name: Build & Submit Android to Google Play
+    needs: android-release-lint
     runs-on: [self-hosted, macOS, ARM64, macos-builder]
     timeout-minutes: 120
     steps:

--- a/packages/app/app.config.js
+++ b/packages/app/app.config.js
@@ -7,6 +7,8 @@ const DevelopmentBuildNumberPattern = /^[1-9]\d{0,3}\.[1-9]\d?$/u;
 const IS_DEV = APP_VARIANT === 'development';
 const IS_E2E = APP_VARIANT === 'e2e';
 const IS_PREVIEW = APP_VARIANT === 'preview';
+const IS_PRODUCTION = APP_VARIANT === 'production';
+const StoreBuildArchs = ['armeabi-v7a', 'arm64-v8a'];
 
 if (DEVELOPMENT_BUILD_NUMBER !== undefined && !DevelopmentBuildNumberPattern.test(DEVELOPMENT_BUILD_NUMBER)) {
     throw new Error('DEVELOPMENT_BUILD_NUMBER must contain a 1-9999 run number and a 1-99 run attempt.');
@@ -129,6 +131,7 @@ export default ({ config }) => ({
             {
                 buildReactNativeFromSource: false,
                 useHermesV1: true,
+                ...(IS_PRODUCTION && { android: { buildArchs: StoreBuildArchs } }),
                 ios: {
                     ccacheEnabled: true,
                     usePrecompiledModules: true

--- a/packages/app/eas.json
+++ b/packages/app/eas.json
@@ -50,7 +50,10 @@
                 "APP_VARIANT": "production",
                 "EAS_USE_CACHE": "1"
             },
-            "channel": "production"
+            "channel": "production",
+            "android": {
+                "gradleCommand": ":app:bundleRelease -x lint -x lintVitalAnalyzeRelease -x lintAnalyzeRelease"
+            }
         }
     },
     "submit": {


### PR DESCRIPTION
## Why

The `workflow_dispatch` store publish is the slowest workflow in the repo. Run [30144992409](https://github.com/vitalyiegorov/suuudokuuu/actions/runs/30144992409) was dispatched at `05:00:22Z` and after 93 minutes the Android job was still inside a single Gradle step, while the iOS job had not started at all.

## Measured attribution

### Job "Build & Submit Android to Google Play" (run 30144992409, job 89644981373)

Step-level wall time from the Actions API. **Step 11 had not completed when this PR was opened** (started `05:09:11Z`, still `in_progress` at `06:33Z`), so its total is a lower bound and its internal breakdown could not be read from the job log — GitHub only serves job logs after the job finishes.

| # | Step | Duration |
|---|---|---|
| 1 | Set up job | 6s |
| 2 | Checkout repository | 22s |
| 3 | Setup Node | 32s |
| 4 | Setup Java | 16s |
| 5 | Setup Android SDK | 61s |
| 6 | Configure Android toolchain | 0s |
| 7 | Verify release credentials | 0s |
| 8 | Setup Expo and EAS | 26s |
| 9 | Google Play service account file creation | 0s |
| 10 | Install dependencies | 13s |
| 11 | **Build Android app locally** | **>= 5040s (84+ min, unfinished)** |
| 12-14 | Upload artifact, submit, credential cleanup | not reached |

Everything before the Gradle build costs 176s combined. All of the cost is inside step 11.

### Inside the Gradle build

Because the live log is not retrievable, the in-step numbers below come from the most recent completed Android release build on the same runner image and same host (the E2E `assembleRelease`, 12.1 min, 721s of log span). Per-ABI CMake wall time, attributed by differencing `> Task :` timestamps:

| ABI | CMake configure + build wall time | Ships to Play today |
|---|---|---|
| `x86` | 67.0s | emulators only |
| `armeabi-v7a` | 47.0s | yes, 32-bit phones |
| `x86_64` | 43.0s | emulators, Intel Chromebooks |
| `arm64-v8a` | 13.0s | yes, required by Play |
| total | 170.0s | |

The four ABIs are built for `:app`, `:expo-modules-core`, `:expo-updates`, `:react-native-reanimated`, `:react-native-screens`, `:react-native-worklets` and `:react-native-gesture-handler`.

Second finding from the same log, a mid-build SDK install during the configuration phase:

```
> Configure project :expo-updates
Checking the license for package NDK (Side by side) 27.0.12077973
Preparing "Install NDK (Side by side) 27.0.12077973"      21:15:09.996
"Install NDK (Side by side) 27.0.12077973" ready.         21:15:54.686
```

45.0s of NDK download inside Gradle configuration. Root cause: `expo-updates/android/build.gradle` declares an `externalNativeBuild { cmake { ... } }` but is the only native module that does not read `rootProject.ext.ndkVersion` (which `ExpoRootProjectPlugin.kt` sets to `27.1.12297006`), so AGP falls back to its own default NDK `27.0.12077973` and downloads it. The publish workflow installs only `27.1.12297006`, so this download happens on every publish run.

Baseline verified locally with `expo prebuild --platform android`: generated `android/gradle.properties` contains `reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64`. Nothing in `eas.json`, `app.config.js` or the Expo config restricted ABIs before this PR.

## Changes

| Change | Expected saving |
|---|---|
| Production variant builds only `armeabi-v7a` + `arm64-v8a` (`expo-build-properties` `buildArchs`) | ~110s of CMake compile, plus per-ABI configure, `mergeReleaseNativeLibs`, strip and bundle packaging; bundle also gets ~2 fewer copies of every `.so`, which shrinks the artifact upload and the submit transfer |
| `ndk;27.0.12077973` added to the Android SDK setup, and the toolchain step now warns when either NDK is absent | up to 45s once the runner base image prewarms it (see follow-up below); until then the same download simply happens in step 5 instead of stalling Gradle configuration |
| `cmake;3.22.1` added to the same package list | 0s today (the image already has it), prevents a silent mid-build download if the image changes |
| New "Verify packaged Android ABIs" step before upload/submit | costs ~1s, guards the change above |

Total measured, attributable saving from the ABI and NDK work: ~110s now, ~155s once the base image carries the AGP-default NDK. The lint change below is far larger.

The 84+ minute step 11 in this run is far larger than the sum of these known costs. That remainder is now accounted for and fixed — see the next section.

## The dominant cost: Android Lint inside the submission build

Configuration-level evidence, decisive on its own:

| Profile | `android.gradleCommand` | Measured |
|---|---|---|
| `e2e` | `:app:assembleRelease -x lint -x lintVitalAnalyzeRelease -x lintAnalyzeRelease` | **12.1 min** |
| `production` | absent, so no lint exclusions | **90+ min** (run 30144992409) |

`.github/workflows/android-maestro.yml:63` uses the same fast path directly: `./gradlew :app:assembleRelease -x lint -x lintVitalAnalyzeRelease -x lintAnalyzeRelease --no-daemon`. Same repo, same host, same native modules, same ABIs — the exclusions are the only meaningful difference, and AGP wires `lintVitalRelease` into release assembly/bundling. Android Lint was therefore running inline inside the store submission build.

Note this also rules out the narrower variant of the fix: plain `lint` and `lintAnalyzeRelease` are not in `bundleRelease`'s task graph at all, so excluding only those would have saved ~0s. The task that must come off the critical path is `lintVital`.

### What changed and where the check now lives

- `production.android.gradleCommand` is now `:app:bundleRelease -x lint -x lintVitalAnalyzeRelease -x lintAnalyzeRelease` — the exclusion set is byte-identical to the `e2e` profile and to `android-maestro.yml`, so the task names are already proven valid in this project. `:app:bundleRelease` is what `buildType: app-bundle` runs, and it is certain to be today's task because the current build produces the `.aab` that `eas submit` consumes.
- **The check was not deleted.** A new `android-release-lint` job runs `:app:lintVitalRelease` against the same production Expo config (`APP_VARIANT=production` prebuild), on a hosted `ubuntu-latest` runner — the same class of runner `pr.yml` and `codeql.yml` already use, so it consumes no fleet capacity and never touches the macOS builder.
- **Submission is still gated on it.** `android-build-and-publish` declares `needs: android-release-lint`. If `lintVitalRelease` reports a fatal issue, the Android build and the Google Play submission never run. The lint report is uploaded as an artifact on failure.
- The iOS job is deliberately not gated on it, matching today's behaviour where the two platform jobs are independent. A lint failure blocks the Play submission only.

**Tradeoff for a human to veto:** the gate is serial (it runs before the build) rather than concurrent, because making it concurrent would require splitting `eas submit` into its own job, and I would not restructure a real store-submission path I cannot test end to end. The natural follow-up, once #216 lands, is to attach this check to the Android build that already happens at PR time.

### Expected impact

| | Before | After |
|---|---|---|
| Android Gradle step | 90+ min (hit the 120 min timeout window) | ~12 min, the `e2e` profile's shape, minus ~110s ABI trim and up to 45s NDK preinstall |
| Lint gate | inline, on the macOS builder | ~10-25 min on a hosted Linux runner, before the builder is claimed |
| macOS builder occupancy | 90+ min | ~10 min |
| iOS job queue wait behind Android | 90+ min | ~10 min |

The builder-occupancy drop is the part that unblocks other tenants on the shared host.

## ABI product impact — please review and veto if wrong

**The production Play bundle will no longer contain `x86` or `x86_64` native libraries.**

- `arm64-v8a` is kept. It is what Play requires and what every current Android phone and tablet uses.
- `armeabi-v7a` is kept, so 32-bit ARM devices are unaffected.
- `x86` has no modern consumer device; it is emulator-only in practice.
- `x86_64` affects Intel Chromebooks and x86 emulators. ChromeOS ARC runs ARM binaries through native-bridge translation, so Intel Chromebook users should still install and run the app, with a performance penalty on native code. Google Play Games on PC would need `x86_64`, but this project is not enrolled in it.
- Nothing in the repo indicates Chromebook, ChromeOS or emulator distribution: no ChromeOS or large-screen configuration, no Play Games on PC setup, no `x86` requirement anywhere in `app.config.js` or `eas.json`.

If any of that is wrong for the actual Play listing, revert by deleting the `buildArchs` line in `app.config.js`; nothing else depends on it.

Two consequences worth knowing:

1. `development`, `preview` and `e2e` variants keep all four ABIs, verified by running `expo prebuild` for each variant and reading the generated `gradle.properties`. Local x86_64 emulator workflows and the E2E pipeline are untouched.
2. `runtimeVersion.policy` is `fingerprint`, so the production fingerprint changes. That is correct — a bundle with a different native ABI set is a different native runtime — but it means the next production build starts a new OTA update lineage and misses the `buildCacheProvider: 'eas'` cache once.

## Verification

- `expo prebuild --platform android` per variant: production emits `reactNativeArchitectures=armeabi-v7a,arm64-v8a`, the other three emit all four ABIs.
- `actionlint` on the workflow: no new findings (the two `macos-builder` custom-label warnings are present on `main` too).
- YAML parses. `needs:` graph checked: `ios-build-and-publish` independent, `android-release-lint` independent, `android-build-and-publish` needs `android-release-lint`. The 14 steps of the publish job, including submit and the `if: always()` credential cleanup, are unchanged and still last.
- The NDK check emits `::warning::` rather than failing. A missing NDK only costs time, so it must not be able to fail a store release; the ABI check is fatal because it protects what gets submitted.
- `bash -n` on both changed `run:` blocks, plus a functional test of the ABI check against a bundle containing `arm64-v8a` (passes) and one containing only `x86_64` (fails with the intended error).
- `yarn ts`, `yarn lint`, `yarn deadcode`, `yarn cpd` all pass.

## Deliberately not touched

- **Signing, credentials, submission.** No change to `eas submit`, the ASC key or Play service-account handling, and both `if: always()` credential-cleanup steps are untouched.
- **Version and build-number logic.** `autoIncrement`, `appVersionSource: remote` and the submit tracks are unchanged.
- **No Gradle cache for this workflow.** The equivalent cache measured 1.82 GB and took 172s to restore at ~11 MB/s. This workflow is manually dispatched and runs rarely, so its cache would nearly always be cold, and four copies of that cache already consume ~7.3 GB of the repo's 10 GB Actions cache quota and LRU-evict the caches that PR workflows rely on. Not worth it here.
- **The E2E workflows and `prewarm-android-buildsdk-macos.sh`**, owned by #216.
- **Runner topology.** Both jobs need macOS: iOS needs Xcode, and the Android build needs the arm64-native darwin NDK because Google ships no arm64 Linux NDK. During this run only one self-hosted runner was online, which is why the iOS job sat queued for 90+ minutes. That is runner capacity, not something this workflow can fix.
- **`usePrecompiledHeaders`** in `expo-build-properties`, which would speed up C++ compilation. It is flagged experimental and would apply to every variant including the E2E builds owned by #216.

## Recommended follow-up

Add `ndk;27.0.12077973` to `tests/app-tests/scripts/prewarm-android-buildsdk-macos.sh` so the AGP-default NDK is baked into the base image. That file is being edited by #216, so it is left alone here to avoid a conflict.
