### PR TITLE
ci: cache Gradle in the Android release lint gate

### DIFF
--- a/.github/workflows/native-publish.yml
+++ b/.github/workflows/native-publish.yml
@@ -156,6 +156,15 @@ jobs:
                   APP_VARIANT: production
               run: ../../node_modules/.bin/expo prebuild --platform android --no-install --clean
 
+            - name: Cache Gradle
+              uses: actions/cache@v5
+              with:
+                  path: |
+                      ~/.gradle/caches
+                      ~/.gradle/wrapper
+                  key: gradle-lint-v1-${{ runner.os }}-arm64-v8a-${{ hashFiles('packages/app/android/gradle/wrapper/gradle-wrapper.properties', 'yarn.lock') }}
+                  restore-keys: gradle-lint-v1-${{ runner.os }}-arm64-v8a-
+
             - name: Run release lint
               working-directory: packages/app/android
               run: ./gradlew :app:lintVitalRelease -PreactNativeArchitectures=arm64-v8a --no-daemon


### PR DESCRIPTION
`android-release-lint` took **50 minutes** of the last store release (14:53 → 15:43 on run 30207015736) and blocks `android-build-and-publish` through `needs:`, so it sits on the critical path of every submission.

The job does a cold `expo prebuild --clean` followed by `./gradlew :app:lintVitalRelease` on a hosted runner with **no Gradle cache**, so every dependency is re-downloaded and re-compiled each release. `mobile-build.yml` in this repo already caches `~/.gradle/caches` and `~/.gradle/wrapper`; this mirrors that pattern with its own key namespace.

The cache step is placed **after** `Generate Android project` on purpose — `prebuild --clean` regenerates `packages/app/android`, so `gradle-wrapper.properties` does not exist before it and `hashFiles` would produce an empty hash.

Scope note: the wider release cost is not duplicated lint work. `eas.json`'s `production` profile already passes `-x lint -x lintVitalAnalyzeRelease -x lintAnalyzeRelease`, so the store build correctly skips the lint this gate performs. The remaining serialization between the iOS and Android submit jobs is a host limit, not config: both need `macos-builder` and the fleet caps that profile at `maxActive: 1` because two 6-vCPU builders would exceed the 10-core host.