### PR TITLE
fix(solver,app): classify technique-enabled placements instead of Guess

### DIFF
--- a/packages/app/src/challenge/utils/classify-timeline-move.util.spec.ts
+++ b/packages/app/src/challenge/utils/classify-timeline-move.util.spec.ts
@@ -6,6 +6,18 @@ import { classifyTimelineMove } from './classify-timeline-move.util';
 
 const givens = '53..7....6..195....98....6.8...6...34..8.3..17...2...6.6....28....419..5....8..79';
 
+const enabledPlacementBoard = [
+    '.1.36..4.',
+    '.3..5....',
+    '24.9....8',
+    '829..5..6',
+    '453.26...',
+    '761.39...',
+    '68.29...1',
+    '.925.....',
+    '.746..9..'
+];
+
 describe('classifyTimelineMove', () => {
     it('should classify a placement into a known technique', () => {
         expect.assertions(1);
@@ -14,5 +26,14 @@ describe('classifyTimelineMove', () => {
         const technique = classifyTimelineMove(sudoku, { ...sudoku.Field[0][2], value: 4 });
 
         expect(Object.values(SolutionTechniqueEnum)).toContain(technique);
+    });
+
+    it('should record the enabling technique instead of a guess', () => {
+        expect.assertions(1);
+
+        const sudoku = Sudoku.fromStrings(defaultSudokuConfig, ...enabledPlacementBoard);
+        const technique = classifyTimelineMove(sudoku, { ...sudoku.Field[6][5], value: 3 });
+
+        expect(technique).toBe(SolutionTechniqueEnum.BoxLineReduction);
     });
 });

--- a/packages/solver/AGENTS.md
+++ b/packages/solver/AGENTS.md
@@ -51,6 +51,24 @@ identifyMove(cell: CellInterface): MoveClassificationInterface  // Technique and
 
 Logical strategies run in `SolutionTechniqueEnum` difficulty order from `createTechniqueStrategies`. The manager exits at the first strategy that finds a result, and fallback `GuessTechnique` runs only when no supported logical technique matches. Techniques that only differ by size/name use descriptor-backed family strategies instead of empty subclasses.
 
+`identifyMove` classifies in two ordered passes, each walking the registry in difficulty order:
+
+1. Direct — the strategy places the played value in the played cell, or its eliminations leave that value as the only candidate there.
+2. Enabling — the strategy's eliminations, applied to a transient context via `CandidateContext.withEliminations`, turn the played value into a naked or hidden single at the played cell (`isForcedPlacement`). The pass is skipped when the placement is already forced without those eliminations, so a technique is never credited for a deduction it did not cause.
+
+A direct justification is one deduction step and always outranks an enabling one, which is two. Only moves that would otherwise fall through to `Guess` can reach the enabling pass.
+
+### TechniqueSearchTargetInterface
+
+`find(context, target)` narrows a scan to one move. `target.intent` says which pass is asking:
+
+- `'direct'` — the caller wants the played cell's other candidates eliminated, so strategies may restrict to those values and to eliminations landing on that cell.
+- `'enabling'` — the caller wants the played value eliminated elsewhere, so strategies may restrict to `target.value` but must not restrict eliminations to the played cell.
+
+`getSearchScope` resolves both narrowings at once: `eliminationValues` for either intent, and `directTarget` only when the intent is `'direct'`. A strategy that cannot narrow an enabling scan safely leaves `directTarget` unused and scans broadly, which stays correct and only costs time.
+
+Ignoring `target` entirely also stays correct for both intents.
+
 ### SolutionTechniqueEnum
 
 Enum values double as difficulty ranking (lower = simpler); `Guess = 0` is the fallback, never emitted by logical strategies. `SimpleColoring` and `AIC` are represented by their own feature folders and are part of the technique registry; keep their enum names and labels aligned with those modules.

--- a/packages/solver/src/@generic/classes/abstract-fish-technique.ts
+++ b/packages/solver/src/@generic/classes/abstract-fish-technique.ts
@@ -1,4 +1,5 @@
 import { getCombinations } from '../utils/get-combinations.util';
+import { getSearchScope } from '../utils/get-search-scope.util';
 
 import { AbstractSizedTechnique } from './abstract-sized-technique';
 
@@ -15,14 +16,11 @@ export abstract class AbstractFishTechnique<
     TDescriptor extends SizedTechniqueDescriptorInterface = SizedTechniqueDescriptorInterface
 > extends AbstractSizedTechnique<TDescriptor> {
     find(context: CandidateContext, target?: TechniqueSearchTargetInterface): TechniqueResultInterface[] {
-        const eliminationValues = target
-            ? context.getCandidates(target.cell).filter(candidate => candidate !== target.value)
-            : context.getValues();
-        const targetCell = target?.cell;
+        const { eliminationValues, directTarget } = getSearchScope(context, target);
 
         return [
-            ...this.findByBaseType(context, 'row', eliminationValues, targetCell),
-            ...this.findByBaseType(context, 'column', eliminationValues, targetCell)
+            ...this.findByBaseType(context, 'row', eliminationValues, directTarget?.cell),
+            ...this.findByBaseType(context, 'column', eliminationValues, directTarget?.cell)
         ];
     }
 

--- a/packages/solver/src/@generic/classes/candidate-context/candidate-context.spec.ts
+++ b/packages/solver/src/@generic/classes/candidate-context/candidate-context.spec.ts
@@ -57,6 +57,27 @@ describe('CandidateContext', () => {
         expect(context.getCandidates(field[0][0])).toEqual([1, 2]);
     });
 
+    it('should return a snapshot without the eliminated candidates', () => {
+        expect.assertions(3);
+
+        const field = Sudoku.fromString(
+            '.'.repeat(defaultSudokuConfig.fieldSize * defaultSudokuConfig.fieldSize),
+            defaultSudokuConfig
+        ).Field;
+        const context = new CandidateContext(defaultSudokuConfig, field, {
+            [getCellKey(field[0][0])]: [1, 2, 3],
+            [getCellKey(field[0][1])]: [1, 2]
+        });
+        const reducedContext = context.withEliminations([
+            { cell: field[0][0], value: 2 },
+            { cell: field[0][0], value: 3 }
+        ]);
+
+        expect(reducedContext.getCandidates(field[0][0])).toEqual([1]);
+        expect(reducedContext.getCandidates(field[0][1])).toEqual([1, 2]);
+        expect(context.getCandidates(field[0][0])).toEqual([1, 2, 3]);
+    });
+
     it('should return row column and group cells', () => {
         expect.assertions(3);
 

--- a/packages/solver/src/@generic/classes/candidate-context/candidate-context.ts
+++ b/packages/solver/src/@generic/classes/candidate-context/candidate-context.ts
@@ -1,5 +1,6 @@
 import { isDefined, isNotEmptyArray } from '@rnw-community/shared';
 
+import type { CandidateEliminationInterface } from '../../interfaces/candidate-elimination.interface';
 import type { CandidateUnitInterface } from '../../interfaces/candidate-unit.interface';
 import type { CandidateMapType } from '../../types/candidate-map.type';
 import type { CellInterface, FieldInterface, Sudoku, SudokuConfigInterface } from '@suuudokuuu/generator';
@@ -39,6 +40,27 @@ export class CandidateContext {
 
     getCandidates(cell: CellInterface): readonly number[] {
         return this.candidateMap[CandidateContext.getCellKey(cell)];
+    }
+
+    withEliminations(eliminations: CandidateEliminationInterface[]): CandidateContext {
+        const eliminatedValuesByCellKey: Record<string, number[]> = {};
+
+        for (const elimination of eliminations) {
+            const key = CandidateContext.getCellKey(elimination.cell);
+
+            eliminatedValuesByCellKey[key] = [...(eliminatedValuesByCellKey[key] ?? []), elimination.value];
+        }
+
+        const candidateMap: CandidateMapType = {};
+
+        for (const cell of this.cells) {
+            const key = CandidateContext.getCellKey(cell);
+            const eliminatedValues = eliminatedValuesByCellKey[key] ?? [];
+
+            candidateMap[key] = this.candidateMap[key].filter(candidate => !eliminatedValues.includes(candidate));
+        }
+
+        return new CandidateContext(this.config, this.field, candidateMap);
     }
 
     isBlankCell(cell: CellInterface): boolean {

--- a/packages/solver/src/@generic/classes/technique-manager/technique-manager.spec.ts
+++ b/packages/solver/src/@generic/classes/technique-manager/technique-manager.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 import { Sudoku, defaultSudokuConfig } from '@suuudokuuu/generator';
 
 import { SolutionTechniqueEnum } from '../../enums/solution-technique.enum';
+import { CandidateContext } from '../candidate-context/candidate-context';
 
 import { TechniqueManager } from './technique-manager';
 
@@ -12,6 +13,30 @@ const createEmptyStrategy = (): TechniqueStrategyInterface => ({
     find: () => [],
     technique: SolutionTechniqueEnum.FullHouse
 });
+
+const xWingEnabledBoard = [
+    '...6.....',
+    '..6......',
+    '57.3.1.86',
+    '125973648',
+    '698.1.732',
+    '437268.5.',
+    '86..5..1.',
+    '.5182649.',
+    '.4.13.865'
+];
+
+const boxLineEnabledBoard = [
+    '.1.36..4.',
+    '.3..5....',
+    '24.9....8',
+    '829..5..6',
+    '453.26...',
+    '761.39...',
+    '68.29...1',
+    '.925.....',
+    '.746..9..'
+];
 
 describe('TechniqueManager', () => {
     it('should find the easiest next logical step', () => {
@@ -78,6 +103,62 @@ describe('TechniqueManager', () => {
             expect.objectContaining({ technique: SolutionTechniqueEnum.FullHouse, cell: sudoku.Field[0][8], value: 9 })
         );
         expect(manager.identifyMove({ ...sudoku.Field[4][4], value: 9 }).technique).toBe(SolutionTechniqueEnum.NakedSingle);
+    });
+
+    it('should classify a placement enabled by an x-wing elimination', () => {
+        expect.assertions(1);
+
+        const sudoku = Sudoku.fromStrings(defaultSudokuConfig, ...xWingEnabledBoard);
+        const [[targetCell]] = sudoku.Field.slice(8);
+        const result = new TechniqueManager(sudoku).identifyMove({ ...targetCell, value: 2 });
+
+        expect(result).toEqual({ technique: SolutionTechniqueEnum.XWing, value: 2 });
+    });
+
+    it('should not attribute an x-wing that does not force the played cell', () => {
+        expect.assertions(1);
+
+        const sudoku = Sudoku.fromStrings(defaultSudokuConfig, ...xWingEnabledBoard);
+        const [[targetCell]] = sudoku.Field;
+        const result = new TechniqueManager(sudoku).identifyMove({ ...targetCell, value: 3 });
+
+        expect(result).toEqual({ technique: SolutionTechniqueEnum.Guess, value: 3 });
+    });
+
+    it('should prefer the simplest enabling technique for a forced placement', () => {
+        expect.assertions(1);
+
+        const sudoku = Sudoku.fromStrings(defaultSudokuConfig, ...boxLineEnabledBoard);
+        const [targetCell] = sudoku.Field[6].slice(5);
+        const result = new TechniqueManager(sudoku).identifyMove({ ...targetCell, value: 3 });
+
+        expect(result).toEqual({ technique: SolutionTechniqueEnum.BoxLineReduction, value: 3 });
+    });
+
+    it('should never justify a value that contradicts the solution', () => {
+        expect.assertions(1);
+
+        const justifiedWrongMoves: string[] = [];
+
+        for (const board of [xWingEnabledBoard, boxLineEnabledBoard]) {
+            const sudoku = Sudoku.fromStrings(defaultSudokuConfig, ...board);
+            const context = CandidateContext.fromSudoku(sudoku);
+            const manager = new TechniqueManager(sudoku);
+
+            for (const cell of context.getBlankCells().slice(0, 6)) {
+                const correctValue = sudoku.getCorrectValue(cell);
+
+                for (const value of context.getCandidates(cell).filter(candidate => candidate !== correctValue)) {
+                    const { technique } = manager.identifyMove({ ...cell, value });
+
+                    if (technique !== SolutionTechniqueEnum.Guess) {
+                        justifiedWrongMoves.push(`r${cell.y + 1}c${cell.x + 1}=${value} as ${SolutionTechniqueEnum[technique]}`);
+                    }
+                }
+            }
+        }
+
+        expect(justifiedWrongMoves).toEqual([]);
     });
 
     it('should mark unsupported moves as guesses', () => {
@@ -166,7 +247,7 @@ describe('TechniqueManager', () => {
 
         expect(result.technique).toBe(SolutionTechniqueEnum.FullHouse);
         expect(findCalls).toBe(1);
-        expect(receivedTarget).toEqual({ cell: targetMove, value: 9 });
+        expect(receivedTarget).toEqual({ cell: targetMove, value: 9, intent: 'direct' });
     });
 
     it('should not treat an eliminated candidate as a justified placement', () => {

--- a/packages/solver/src/@generic/classes/technique-manager/technique-manager.ts
+++ b/packages/solver/src/@generic/classes/technique-manager/technique-manager.ts
@@ -1,10 +1,13 @@
 import { isDefined } from '@rnw-community/shared';
 
 import { GuessTechnique } from '../../../guess-technique/classes/guess.technique';
+import { canSee } from '../../utils/can-see.util';
 import { createTechniqueStrategies } from '../../utils/create-technique-strategies.util';
+import { isForcedPlacement } from '../../utils/is-forced-placement.util';
 import { isSameCell } from '../../utils/is-same-cell.util';
 import { CandidateContext } from '../candidate-context/candidate-context';
 
+import type { SolutionTechniqueEnum } from '../../enums/solution-technique.enum';
 import type { MoveClassificationInterface } from '../../interfaces/move-classification.interface';
 import type { TechniqueResultInterface } from '../../interfaces/technique-result.interface';
 import type { TechniqueStrategyInterface } from '../../interfaces/technique-strategy.interface';
@@ -41,24 +44,54 @@ export class TechniqueManager {
     identifyMove(cell: CellInterface): MoveClassificationInterface {
         const context = CandidateContext.fromSudoku(this.sudoku);
         const targetValue = this.getTargetValue(cell);
+        const technique = this.findDirectTechnique(context, cell, targetValue) ?? this.findEnablingTechnique(context, cell, targetValue);
 
+        return { technique: technique ?? this.guessTechnique.technique, value: targetValue };
+    }
+
+    private findDirectTechnique(context: CandidateContext, cell: CellInterface, value: number): SolutionTechniqueEnum | null {
         for (const strategy of this.strategies) {
-            const results = strategy.find(context, { cell, value: targetValue });
-            const result = results.find(candidate => this.isResultForMove(context, candidate, cell, targetValue));
+            const results = strategy.find(context, { cell, value, intent: 'direct' });
+            const result = results.find(candidate => this.isDirectResult(context, candidate, cell, value));
 
             if (isDefined(result)) {
-                return { technique: result.technique, value: targetValue };
+                return result.technique;
             }
         }
 
-        return { technique: this.guessTechnique.technique, value: targetValue };
+        return null;
+    }
+
+    private findEnablingTechnique(context: CandidateContext, cell: CellInterface, value: number): SolutionTechniqueEnum | null {
+        if (isForcedPlacement(context, cell, value)) {
+            return null;
+        }
+
+        for (const strategy of this.strategies) {
+            const results = strategy.find(context, { cell, value, intent: 'enabling' });
+            const result = results.find(candidate => this.isEnablingResult(context, candidate, cell, value));
+
+            if (isDefined(result)) {
+                return result.technique;
+            }
+        }
+
+        return null;
+    }
+
+    private isEnablingResult(context: CandidateContext, result: TechniqueResultInterface, cell: CellInterface, value: number): boolean {
+        const clearsPeerCandidate = result.eliminations.some(
+            elimination => elimination.value === value && canSee(context, elimination.cell, cell)
+        );
+
+        return clearsPeerCandidate && isForcedPlacement(context.withEliminations(result.eliminations), cell, value);
     }
 
     private getTargetValue(cell: CellInterface): number {
         return cell.value === this.sudoku.Config.blankCellValue ? this.sudoku.getCorrectValue(cell) : cell.value;
     }
 
-    private isResultForMove(context: CandidateContext, result: TechniqueResultInterface, cell: CellInterface, value: number): boolean {
+    private isDirectResult(context: CandidateContext, result: TechniqueResultInterface, cell: CellInterface, value: number): boolean {
         if (result.kind === 'placement') {
             return isSameCell(result.cell, cell) && result.value === value;
         }

--- a/packages/solver/src/@generic/interfaces/technique-search-scope.interface.ts
+++ b/packages/solver/src/@generic/interfaces/technique-search-scope.interface.ts
@@ -1,0 +1,6 @@
+import type { TechniqueSearchTargetInterface } from './technique-search-target.interface';
+
+export interface TechniqueSearchScopeInterface {
+    readonly eliminationValues: number[];
+    readonly directTarget?: TechniqueSearchTargetInterface;
+}

--- a/packages/solver/src/@generic/interfaces/technique-search-target.interface.ts
+++ b/packages/solver/src/@generic/interfaces/technique-search-target.interface.ts
@@ -1,6 +1,8 @@
+import type { TechniqueSearchIntentType } from '../types/technique-search-intent.type';
 import type { CellInterface } from '@suuudokuuu/generator';
 
 export interface TechniqueSearchTargetInterface {
     readonly cell: CellInterface;
     readonly value: number;
+    readonly intent: TechniqueSearchIntentType;
 }

--- a/packages/solver/src/@generic/types/technique-search-intent.type.ts
+++ b/packages/solver/src/@generic/types/technique-search-intent.type.ts
@@ -1,0 +1,1 @@
+export type TechniqueSearchIntentType = 'direct' | 'enabling';

--- a/packages/solver/src/@generic/utils/collect-chain-results.util.ts
+++ b/packages/solver/src/@generic/utils/collect-chain-results.util.ts
@@ -1,0 +1,23 @@
+import { isDefined } from '@rnw-community/shared';
+
+import { getCanonicalTechniqueResults } from './get-canonical-technique-results.util';
+
+import type { TechniqueResultInterface } from '../interfaces/technique-result.interface';
+import type { TechniqueSearchScopeInterface } from '../interfaces/technique-search-scope.interface';
+
+export const collectChainResults = (
+    scope: TechniqueSearchScopeInterface,
+    collectForValue: (eliminationValue: number, results: TechniqueResultInterface[]) => void
+): TechniqueResultInterface[] => {
+    const results: TechniqueResultInterface[] = [];
+
+    for (const eliminationValue of scope.eliminationValues) {
+        collectForValue(eliminationValue, results);
+
+        if (isDefined(scope.directTarget) && results.length > 0) {
+            return results;
+        }
+    }
+
+    return isDefined(scope.directTarget) ? results : getCanonicalTechniqueResults(results);
+};

--- a/packages/solver/src/@generic/utils/get-search-elimination-values.util.ts
+++ b/packages/solver/src/@generic/utils/get-search-elimination-values.util.ts
@@ -6,6 +6,10 @@ export const getSearchEliminationValues = (context: CandidateContext, target?: T
         return context.getValues();
     }
 
+    if (target.intent === 'enabling') {
+        return [target.value];
+    }
+
     return context
         .getCandidates(target.cell)
         .filter(value => value !== target.value)

--- a/packages/solver/src/@generic/utils/get-search-scope.util.ts
+++ b/packages/solver/src/@generic/utils/get-search-scope.util.ts
@@ -1,0 +1,10 @@
+import { getSearchEliminationValues } from './get-search-elimination-values.util';
+
+import type { CandidateContext } from '../classes/candidate-context/candidate-context';
+import type { TechniqueSearchScopeInterface } from '../interfaces/technique-search-scope.interface';
+import type { TechniqueSearchTargetInterface } from '../interfaces/technique-search-target.interface';
+
+export const getSearchScope = (context: CandidateContext, target?: TechniqueSearchTargetInterface): TechniqueSearchScopeInterface => ({
+    eliminationValues: getSearchEliminationValues(context, target),
+    ...(target?.intent === 'direct' && { directTarget: target })
+});

--- a/packages/solver/src/@generic/utils/is-forced-placement.util.ts
+++ b/packages/solver/src/@generic/utils/is-forced-placement.util.ts
@@ -1,0 +1,20 @@
+import { isSameCell } from './is-same-cell.util';
+
+import type { CandidateContext } from '../classes/candidate-context/candidate-context';
+import type { CellInterface } from '@suuudokuuu/generator';
+
+export const isForcedPlacement = (context: CandidateContext, cell: CellInterface, value: number): boolean => {
+    const candidates = context.getCandidates(cell);
+
+    if (!candidates.includes(value)) {
+        return false;
+    }
+
+    if (candidates.length === 1) {
+        return true;
+    }
+
+    const unitCells = [context.getRowCells(cell.y), context.getColumnCells(cell.x), context.getGroupCells(cell)];
+
+    return unitCells.some(cells => cells.every(unitCell => isSameCell(unitCell, cell) || !context.getCandidates(unitCell).includes(value)));
+};

--- a/packages/solver/src/@generic/utils/technique-helpers.spec.ts
+++ b/packages/solver/src/@generic/utils/technique-helpers.spec.ts
@@ -9,10 +9,13 @@ import { createPlacementResult } from './create-placement-result.util';
 import { getBivalueCells } from './get-bivalue-cells.util';
 import { getCombinations } from './get-combinations.util';
 import { getCommonPeerEliminations } from './get-common-peer-eliminations.util';
+import { getSearchEliminationValues } from './get-search-elimination-values.util';
+import { getSearchScope } from './get-search-scope.util';
 import { getUniqueCells } from './get-unique-cells.util';
 import { getUniqueValues } from './get-unique-values.util';
 import { hasSameCandidates } from './has-same-candidates.util';
 import { hasStrongLinkBetween } from './has-strong-link-between.util';
+import { isForcedPlacement } from './is-forced-placement.util';
 import { isSameCell } from './is-same-cell.util';
 
 describe('technique helpers', () => {
@@ -72,6 +75,35 @@ describe('technique helpers', () => {
         expect(hasSameCandidates([1, 2], [2, 1])).toBe(true);
         expect(hasStrongLinkBetween(context, firstCell, thirdCell, 1)).toBe(true);
         expect(getBivalueCells(context)).toEqual([firstCell, secondCell, thirdCell]);
+    });
+
+    it('recognizes naked and hidden forced placements', () => {
+        expect.assertions(4);
+
+        const nakedContext = createCandidateContextFromMap([0, 0, [7]]);
+        const hiddenContext = createCandidateContextFromMap([0, 0, [7, 8]], [0, 1, [8, 9]], [1, 0, [8, 9]]);
+        const [nakedCell] = nakedContext.getRowCells(0);
+        const [hiddenCell] = hiddenContext.getRowCells(0);
+
+        expect(isForcedPlacement(nakedContext, nakedCell, 7)).toBe(true);
+        expect(isForcedPlacement(nakedContext, nakedCell, 8)).toBe(false);
+        expect(isForcedPlacement(hiddenContext, hiddenCell, 7)).toBe(true);
+        expect(isForcedPlacement(hiddenContext, hiddenCell, 8)).toBe(false);
+    });
+
+    it('narrows the search by the requested intent', () => {
+        expect.assertions(5);
+
+        const context = createCandidateContextFromMap([0, 0, [1, 2, 3]]);
+        const [cell] = context.getRowCells(0);
+        const directTarget = { cell, value: 2, intent: 'direct' } as const;
+        const enablingTarget = { cell, value: 2, intent: 'enabling' } as const;
+
+        expect(getSearchEliminationValues(context, directTarget)).toEqual([1, 3]);
+        expect(getSearchEliminationValues(context, enablingTarget)).toEqual([2]);
+        expect(getSearchEliminationValues(context)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        expect(getSearchScope(context, directTarget)).toEqual({ eliminationValues: [1, 3], directTarget });
+        expect(getSearchScope(context, enablingTarget)).toEqual({ eliminationValues: [2] });
     });
 
     it('finds common peer eliminations', () => {

--- a/packages/solver/src/aic-technique/classes/aic.technique.spec.ts
+++ b/packages/solver/src/aic-technique/classes/aic.technique.spec.ts
@@ -74,7 +74,7 @@ describe('AICTechnique', () => {
         const context = createCandidateContextFromMap([0, 0, [1, 2]], [0, 3, [1, 2]], [0, 4, [1, 6]]);
         const [targetCell] = context.getRowCells(0).slice(4, 5);
 
-        expectTechniqueResults(context, new AICTechnique().find(context, { cell: targetCell, value: 6 }), [
+        expectTechniqueResults(context, new AICTechnique().find(context, { cell: targetCell, value: 6, intent: 'direct' }), [
             {
                 technique: SolutionTechniqueEnum.AIC,
                 kind: 'elimination',
@@ -94,7 +94,7 @@ describe('AICTechnique', () => {
         const context = createCandidateContextFromMap([0, 0, [1, 2]], [0, 3, [1, 2]], [0, 4, [1, 5, 6]]);
         const [targetCell] = context.getRowCells(0).slice(4, 5);
 
-        expect(new AICTechnique().find(context, { cell: targetCell, value: 6 })).toEqual([]);
+        expect(new AICTechnique().find(context, { cell: targetCell, value: 6, intent: 'direct' })).toEqual([]);
     });
 
     it('uses one visit budget across all broad-search roots', () => {

--- a/packages/solver/src/aic-technique/classes/aic.technique.ts
+++ b/packages/solver/src/aic-technique/classes/aic.technique.ts
@@ -5,6 +5,7 @@ import { SolutionTechniqueEnum } from '../../@generic/enums/solution-technique.e
 import { createEliminationResults } from '../../@generic/utils/create-elimination-results.util';
 import { getCanonicalTechniqueResults } from '../../@generic/utils/get-canonical-technique-results.util';
 import { getCombinations } from '../../@generic/utils/get-combinations.util';
+import { getSearchScope } from '../../@generic/utils/get-search-scope.util';
 import { getUniqueCells } from '../../@generic/utils/get-unique-cells.util';
 import { isSameCell } from '../../@generic/utils/is-same-cell.util';
 import { AIC_MAX_LINK_VISITS, AIC_MIN_NODES } from '../constants/aic.constant';
@@ -22,9 +23,10 @@ import type { CellInterface } from '@suuudokuuu/generator';
 export class AICTechnique implements TechniqueStrategyInterface {
     readonly technique = SolutionTechniqueEnum.AIC;
 
-    find(context: CandidateContext, target?: TechniqueSearchTargetInterface): TechniqueResultInterface[] {
+    find(context: CandidateContext, searchTarget?: TechniqueSearchTargetInterface): TechniqueResultInterface[] {
         const graph = this.createGraph(context);
         const results: TechniqueResultInterface[] = [];
+        const { directTarget: target } = getSearchScope(context, searchTarget);
         const startNodes = this.getStartNodes(graph, target);
 
         if (target) {

--- a/packages/solver/src/finned-swordfish-technique/classes/finned-swordfish.technique.spec.ts
+++ b/packages/solver/src/finned-swordfish-technique/classes/finned-swordfish.technique.spec.ts
@@ -89,7 +89,8 @@ describe('FinnedSwordfishTechnique', () => {
             context,
             new FinnedFishTechnique({ technique: SolutionTechniqueEnum.FinnedSwordfish, size: 3, sashimi: false }).find(context, {
                 cell: targetCell,
-                value: 8
+                value: 8,
+                intent: 'direct'
             }),
             [
                 {

--- a/packages/solver/src/x-chain-technique/classes/x-chain.technique.spec.ts
+++ b/packages/solver/src/x-chain-technique/classes/x-chain.technique.spec.ts
@@ -176,7 +176,7 @@ describe('XChainTechnique', () => {
         const context = createCandidateContextFromMap(...candidateMap);
         const targetCell = context.getRowCells(target[0])[target[1]];
 
-        expectTechniqueResults(context, new XChainTechnique().find(context, { cell: targetCell, value: target[2] }), [
+        expectTechniqueResults(context, new XChainTechnique().find(context, { cell: targetCell, value: target[2], intent: 'direct' }), [
             {
                 technique: SolutionTechniqueEnum.XChain,
                 kind: 'elimination',
@@ -230,7 +230,7 @@ describe('XChainTechnique', () => {
         const context = createCandidateContextFromMap([0, 0, [5, 6]], [0, 1, [5, 7]], [1, 1, [5, 4]], [1, 4, [5, 8]]);
         const [, targetCell] = context.getRowCells(1);
 
-        expectTechniqueResults(context, new XChainTechnique().find(context, { cell: targetCell, value: 4 }), []);
+        expectTechniqueResults(context, new XChainTechnique().find(context, { cell: targetCell, value: 4, intent: 'direct' }), []);
     });
 
     it('stops after the first deterministic target deduction', () => {
@@ -249,7 +249,7 @@ describe('XChainTechnique', () => {
         );
         const [, , , , targetCell] = context.getRowCells(4);
 
-        expectTechniqueResults(context, new XChainTechnique().find(context, { cell: targetCell, value: 9 }), [
+        expectTechniqueResults(context, new XChainTechnique().find(context, { cell: targetCell, value: 9, intent: 'direct' }), [
             {
                 technique: SolutionTechniqueEnum.XChain,
                 kind: 'elimination',

--- a/packages/solver/src/x-chain-technique/classes/x-chain.technique.ts
+++ b/packages/solver/src/x-chain-technique/classes/x-chain.technique.ts
@@ -2,10 +2,11 @@ import { isDefined } from '@rnw-community/shared';
 
 import { X_CHAIN_MAX_VISITS_PER_ROOT, X_CHAIN_MIN_CELLS } from '../../@generic/constants/chain-scan.constant';
 import { SolutionTechniqueEnum } from '../../@generic/enums/solution-technique.enum';
+import { collectChainResults } from '../../@generic/utils/collect-chain-results.util';
 import { createEliminationResults } from '../../@generic/utils/create-elimination-results.util';
 import { getCanonicalTechniqueResults } from '../../@generic/utils/get-canonical-technique-results.util';
 import { getChainEndpointEliminations } from '../../@generic/utils/get-chain-endpoint-eliminations.util';
-import { getSearchEliminationValues } from '../../@generic/utils/get-search-elimination-values.util';
+import { getSearchScope } from '../../@generic/utils/get-search-scope.util';
 import { getTargetEliminations } from '../../@generic/utils/get-target-eliminations.util';
 import { getUniqueCells } from '../../@generic/utils/get-unique-cells.util';
 import { isSameCell } from '../../@generic/utils/is-same-cell.util';
@@ -25,16 +26,14 @@ const compareCells = (firstCell: CellInterface, secondCell: CellInterface): numb
 export class XChainTechnique implements TechniqueStrategyInterface {
     readonly technique = SolutionTechniqueEnum.XChain;
 
-    find(context: CandidateContext, target?: TechniqueSearchTargetInterface): TechniqueResultInterface[] {
-        const results: TechniqueResultInterface[] = [];
-        const eliminationValues = getSearchEliminationValues(context, target);
+    find(context: CandidateContext, searchTarget?: TechniqueSearchTargetInterface): TechniqueResultInterface[] {
+        const scope = getSearchScope(context, searchTarget);
 
-        for (const eliminationValue of eliminationValues) {
-            const strongLinks = this.getStrongLinks(context, eliminationValue);
-            const roots = this.getRoots(context, eliminationValue, target);
+        return collectChainResults(scope, (eliminationValue, results) => {
+            const target = scope.directTarget;
             const scan = {
                 context,
-                strongLinks,
+                strongLinks: this.getStrongLinks(context, eliminationValue),
                 value: eliminationValue,
                 results,
                 target,
@@ -42,14 +41,8 @@ export class XChainTechnique implements TechniqueStrategyInterface {
                 resultsAtStart: results.length
             };
 
-            this.collectResults(roots, scan);
-
-            if (target && results.length > 0) {
-                return results;
-            }
-        }
-
-        return target ? results : getCanonicalTechniqueResults(results);
+            this.collectResults(this.getRoots(context, eliminationValue, target), scan);
+        });
     }
 
     private getRoots(context: CandidateContext, value: number, target?: TechniqueSearchTargetInterface): CellInterface[] {

--- a/packages/solver/src/x-wing-technique/classes/x-wing.technique.spec.ts
+++ b/packages/solver/src/x-wing-technique/classes/x-wing.technique.spec.ts
@@ -5,6 +5,7 @@ import { CandidateContext } from '../../@generic/classes/candidate-context/candi
 import { SolutionTechniqueEnum } from '../../@generic/enums/solution-technique.enum';
 import { createCandidateContextFromMap } from '../../@generic/test-utils/create-candidate-context-from-map.spec.util';
 import { expectTechniqueResults } from '../../@generic/test-utils/expect-technique-results.spec.util';
+import { isForcedPlacement } from '../../@generic/utils/is-forced-placement.util';
 import { BasicFishTechnique } from '../../basic-fish-technique/classes/basic-fish.technique';
 
 describe('XWingTechnique', () => {
@@ -39,6 +40,41 @@ describe('XWingTechnique', () => {
                 ]
             }
         ]);
+    });
+
+    it('forces a hidden single one elimination step away', () => {
+        expect.assertions(3);
+
+        const sudoku = Sudoku.fromStrings(
+            defaultSudokuConfig,
+            '.1.36..4.',
+            '.3..5....',
+            '24.9....8',
+            '829..5..6',
+            '453.26...',
+            '761.39...',
+            '68.29...1',
+            '.925.....',
+            '.746..9..'
+        );
+        const context = CandidateContext.fromSudoku(sudoku);
+        const [targetCell] = sudoku.Field[6].slice(5);
+        const results = new BasicFishTechnique({ technique: SolutionTechniqueEnum.XWing, size: 2 }).find(context);
+        const baseRowFish = results.find(result => result.reasonCells.every(cell => cell.y === 2 || cell.y === 3));
+
+        expect(baseRowFish?.reasonCells.map(cell => [cell.y, cell.x])).toEqual([
+            [2, 6],
+            [2, 7],
+            [3, 6],
+            [3, 7]
+        ]);
+        expect(baseRowFish?.eliminations.map(elimination => [elimination.cell.y, elimination.cell.x, elimination.value])).toEqual(
+            expect.arrayContaining([
+                [6, 6, 3],
+                [6, 7, 3]
+            ])
+        );
+        expect(isForcedPlacement(context.withEliminations(baseRowFish?.eliminations ?? []), targetCell, 3)).toBe(true);
     });
 
     it('ignores a base row with a third occurrence', () => {

--- a/packages/solver/src/xy-chain-technique/classes/xy-chain.technique.spec.ts
+++ b/packages/solver/src/xy-chain-technique/classes/xy-chain.technique.spec.ts
@@ -63,7 +63,7 @@ describe('XYChainTechnique', () => {
         const context = createCandidateContextFromMap(...candidateMap);
         const targetCell = context.getRowCells(target[0])[target[1]];
 
-        expectTechniqueResults(context, new XYChainTechnique().find(context, { cell: targetCell, value: target[2] }), [
+        expectTechniqueResults(context, new XYChainTechnique().find(context, { cell: targetCell, value: target[2], intent: 'direct' }), [
             {
                 technique: SolutionTechniqueEnum.XYChain,
                 kind: 'elimination',
@@ -99,7 +99,7 @@ describe('XYChainTechnique', () => {
         const context = createCandidateContextFromMap([0, 0, [1, 2]], [1, 1, [1, 2]], [1, 4, [1, 3]], [1, 7, [1, 3]]);
         const [, targetCell] = context.getRowCells(1);
 
-        expectTechniqueResults(context, new XYChainTechnique().find(context, { cell: targetCell, value: 2 }), []);
+        expectTechniqueResults(context, new XYChainTechnique().find(context, { cell: targetCell, value: 2, intent: 'direct' }), []);
     });
 
     it('stops after the first deterministic target deduction', () => {
@@ -116,7 +116,7 @@ describe('XYChainTechnique', () => {
         );
         const [, , , , targetCell] = context.getRowCells(4);
 
-        expectTechniqueResults(context, new XYChainTechnique().find(context, { cell: targetCell, value: 9 }), [
+        expectTechniqueResults(context, new XYChainTechnique().find(context, { cell: targetCell, value: 9, intent: 'direct' }), [
             {
                 technique: SolutionTechniqueEnum.XYChain,
                 kind: 'elimination',

--- a/packages/solver/src/xy-chain-technique/classes/xy-chain.technique.ts
+++ b/packages/solver/src/xy-chain-technique/classes/xy-chain.technique.ts
@@ -2,11 +2,12 @@ import { isDefined } from '@rnw-community/shared';
 
 import { XY_CHAIN_MAX_VISITS_PER_ROOT, XY_CHAIN_MIN_CELLS } from '../../@generic/constants/chain-scan.constant';
 import { SolutionTechniqueEnum } from '../../@generic/enums/solution-technique.enum';
+import { collectChainResults } from '../../@generic/utils/collect-chain-results.util';
 import { createEliminationResults } from '../../@generic/utils/create-elimination-results.util';
 import { getBivalueCells } from '../../@generic/utils/get-bivalue-cells.util';
 import { getCanonicalTechniqueResults } from '../../@generic/utils/get-canonical-technique-results.util';
 import { getChainEndpointEliminations } from '../../@generic/utils/get-chain-endpoint-eliminations.util';
-import { getSearchEliminationValues } from '../../@generic/utils/get-search-elimination-values.util';
+import { getSearchScope } from '../../@generic/utils/get-search-scope.util';
 import { getTargetEliminations } from '../../@generic/utils/get-target-eliminations.util';
 import { isBivalueCell } from '../../@generic/utils/is-bivalue-cell.util';
 import { isSameCell } from '../../@generic/utils/is-same-cell.util';
@@ -24,40 +25,38 @@ const compareCells = (firstCell: CellInterface, secondCell: CellInterface): numb
 export class XYChainTechnique implements TechniqueStrategyInterface {
     readonly technique = SolutionTechniqueEnum.XYChain;
 
-    find(context: CandidateContext, target?: TechniqueSearchTargetInterface): TechniqueResultInterface[] {
-        const results: TechniqueResultInterface[] = [];
-        const eliminationValues = getSearchEliminationValues(context, target);
+    find(context: CandidateContext, searchTarget?: TechniqueSearchTargetInterface): TechniqueResultInterface[] {
+        const scope = getSearchScope(context, searchTarget);
 
-        for (const eliminationValue of eliminationValues) {
+        return collectChainResults(scope, (eliminationValue, results) => {
+            const target = scope.directTarget;
+
             for (const root of this.getRoots(context, eliminationValue, target)) {
-                const linkValue = context.getCandidates(root).find(candidate => candidate !== eliminationValue);
+                const scan = { context, eliminationValue, results, target, linkVisits: 0, resultsAtStart: results.length };
 
-                if (isDefined(linkValue)) {
-                    const scan = {
-                        context,
-                        eliminationValue,
-                        results,
-                        target,
-                        linkVisits: 0,
-                        resultsAtStart: results.length
-                    };
-
-                    this.collectXYChainResults(scan, [root], linkValue);
-
-                    if (scan.target && scan.results.length > scan.resultsAtStart) {
-                        break;
-                    }
-
-                    scan.results.splice(0, scan.results.length, ...getCanonicalTechniqueResults(scan.results));
+                if (this.collectRootResults(scan, root)) {
+                    return;
                 }
             }
+        });
+    }
 
-            if (target && results.length > 0) {
-                return results;
-            }
+    private collectRootResults(scan: XYChainScanInterface, root: CellInterface): boolean {
+        const linkValue = scan.context.getCandidates(root).find(candidate => candidate !== scan.eliminationValue);
+
+        if (!isDefined(linkValue)) {
+            return false;
         }
 
-        return target ? results : getCanonicalTechniqueResults(results);
+        this.collectXYChainResults(scan, [root], linkValue);
+
+        if (scan.target && scan.results.length > scan.resultsAtStart) {
+            return true;
+        }
+
+        scan.results.splice(0, scan.results.length, ...getCanonicalTechniqueResults(scan.results));
+
+        return false;
     }
 
     private getRoots(context: CandidateContext, eliminationValue: number, target?: TechniqueSearchTargetInterface): CellInterface[] {


### PR DESCRIPTION
Closes #228

## Problem

A placement that is logically forced, but only *after* another technique's eliminations, was recorded as a `Guess` — inflating the guess count on the challenge badge, timeline, and replay.

`identifyMove` accepted a technique result only when it placed the value in the played cell, or eliminated candidates **on that cell**. The search target made strategies discard the evidence before it could be considered: `BasicFishTechnique` filtered fish eliminations down to the played cell, so an X-Wing that removes the value from *other* cells in the played row was thrown away.

On the reported board, `r7c6 = 3` is forced because candidate `3` is cleared from `r7c7` and `r7c8`. Those eliminations exist; nothing in the classifier could express "the eliminations landed elsewhere, and that is what forced this cell".

## Fix

`identifyMove` classifies in two ordered passes, each walking the registry in difficulty order:

1. **Direct** — unchanged. Every move that already resolved to a technique keeps exactly that technique, so the change has no regression surface on existing classifications.
2. **Enabling** — apply a result's full eliminations to a transient context (`CandidateContext.withEliminations`) and check whether the played value becomes a naked or hidden single at the played cell (`isForcedPlacement`). Guarded by "not already forced without those eliminations", so a technique is never credited for a deduction it did not cause.

A direct justification is one deduction step and always outranks an enabling one, which is two. Only moves that would otherwise fall through to `Guess` can reach the enabling pass.

### Search intent

`TechniqueSearchTargetInterface` gained `intent`:

- `'direct'` — the caller wants the played cell's other candidates eliminated, so strategies may restrict to those values and to eliminations landing on that cell.
- `'enabling'` — the caller wants the played value eliminated elsewhere, so strategies may restrict to `target.value` but must **not** restrict eliminations to the played cell.

`getSearchScope` resolves both narrowings in one place. Strategies that cannot narrow an enabling scan safely (the chains, AIC) leave `directTarget` unused and scan broadly, which stays correct. Without this narrowing the enabling pass cost a full nine-value fish scan per move — roughly double the current worst case.

## Correction to the issue's acceptance criteria

**The issue's fixture does not classify as `XWing`, and it should not.** On that exact board a Box/Line Reduction — column 9's `3`s are confined to box 9 — produces the *identical* elimination set `r7c7#3 r7c8#3 r8c7#3 r8c8#3 r9c8#3`, at difficulty 6 against X-Wing's 13. Returning `XWing` there would require hardcoding fish above Box/Line Reduction, which contradicts both the difficulty registry and the issue's own scope ("keep move classification deterministic and ordered by the existing technique difficulty registry"), and would relabel correct `BoxLineReduction` moves as harder techniques across every board.

So the fixture asserts `BoxLineReduction`, and the X-Wing causality the issue describes is asserted directly on the same board at the level where it is true. A separate, verified fixture covers the case where X-Wing genuinely is the simplest enabling technique.

## Behaviour on the reported fixture

| move | before | after |
|---|---|---|
| `r7c6 = 3` | `Guess` | `BoxLineReduction` |

## Tests

- `identifyMove` on a board where X-Wing is the simplest enabling technique: `r9c1 = 2`, X-Wing on `2` at `r3c3`/`r3c7`/`r7c3`/`r7c7`, clearing `2` from `r9c3` so `r9c1` is the only `2` left in row 9.
- Negative: same board, `r1c1 = 3` stays a `Guess` — a valid X-Wing exists but does not force that cell, so no board-wide false attribution.
- The reported fixture asserts `BoxLineReduction`.
- X-Wing causality on the reported fixture: reason cells `r3c7`/`r3c8`/`r4c7`/`r4c8`, eliminations covering `r7c7`/`r7c8`, and `r7c6 = 3` forced once they are applied.
- Soundness invariant: across both fixtures, no wrong candidate value is ever justified by a technique.
- Unit coverage for `isForcedPlacement`, `getSearchScope`, and `CandidateContext.withEliminations` snapshot isolation.
- App-level `classifyTimelineMove` regression, so the stored timeline classification is checked at the recording boundary.

Existing direct `FullHouse` / `NakedSingle` / `HiddenSingle` / direct-elimination classifications and the unsupported-move `Guess` tests are unchanged and still pass.

## Performance

The enabling pass only runs when the direct pass finds nothing. Node, steady state:

| | before | after |
|---|---|---|
| move a technique explains | ~7ms | ~5–9ms |
| move that stays a `Guess` | ~21ms | ~33–47ms (max ~57ms) |

The cost lands only on the guess path, in a handler that already did ~21ms of work there.

## Validation

`yarn format && yarn ts && yarn lint && yarn deadcode && yarn cpd` clean (0 duplication clones — the shared chain scan loop was extracted to `collectChainResults` rather than raising the jscpd threshold), `yarn test` 904 passing, `yarn i18n:check` clean. Solver coverage 99.15% statements / 95.1% branches / 100% functions.
