### PR TITLE
fix(app,ui): make game generation single-flight across start and retry actions

### DIFF
--- a/packages/app/src/@generic/components/play-again-button/play-again-button.tsx
+++ b/packages/app/src/@generic/components/play-again-button/play-again-button.tsx
@@ -11,11 +11,12 @@ import { PlayAgainButtonSelectors } from './play-again-button.selectors';
 import type { PressableProps, StyleProp, ViewStyle } from 'react-native';
 
 interface Props {
+    readonly isLoading?: boolean;
     readonly onPress?: PressableProps['onPress'];
     readonly style?: StyleProp<ViewStyle>;
 }
 
-export const PlayAgainButton = ({ onPress, style }: Props) => {
+export const PlayAgainButton = ({ isLoading = false, onPress, style }: Props) => {
     const { t } = useLingui();
 
     const dispatch = useAppDispatch();
@@ -24,5 +25,13 @@ export const PlayAgainButton = ({ onPress, style }: Props) => {
     const hasCustomOnPress = isDefined(onPress);
     const buttonActionProps = hasCustomOnPress ? { onPress } : { href: '/', onPress: handlePlayAgain, replace: true };
 
-    return <BlackButton {...buttonActionProps} style={style} testID={PlayAgainButtonSelectors.Root} text={t`Play again`} />;
+    return (
+        <BlackButton
+            {...buttonActionProps}
+            isLoading={isLoading}
+            style={style}
+            testID={PlayAgainButtonSelectors.Root}
+            text={t`Play again`}
+        />
+    );
 };

--- a/packages/app/src/challenge/components/challenge-accept-screen/challenge-accept-screen.tsx
+++ b/packages/app/src/challenge/components/challenge-accept-screen/challenge-accept-screen.tsx
@@ -30,10 +30,11 @@ const RIVAL_INITIAL = 'R';
 interface Props {
     readonly opponentTotalTime: number;
     readonly challengeState: string;
+    readonly isLoading: boolean;
     readonly onAccept: () => void;
 }
 
-export const ChallengeAcceptScreen = ({ opponentTotalTime, challengeState, onAccept }: Props) => {
+export const ChallengeAcceptScreen = ({ opponentTotalTime, challengeState, isLoading, onAccept }: Props) => {
     const { t } = useLingui();
     const { theme } = use(ThemeContext);
     const opponentTotalTimeText = useTimerText(opponentTotalTime);
@@ -67,7 +68,12 @@ export const ChallengeAcceptScreen = ({ opponentTotalTime, challengeState, onAcc
 
     const footer = (
         <ScreenActionBar right={maybeLaterButton}>
-            <BlackButton onPress={onAccept} testID={ChallengeAcceptScreenSelectors.AcceptButton} text={t`Accept challenge`} />
+            <BlackButton
+                isLoading={isLoading}
+                onPress={onAccept}
+                testID={ChallengeAcceptScreenSelectors.AcceptButton}
+                text={t`Accept challenge`}
+            />
         </ScreenActionBar>
     );
 

--- a/packages/app/src/challenge/components/challenge-try-again-button/challenge-try-again-button.tsx
+++ b/packages/app/src/challenge/components/challenge-try-again-button/challenge-try-again-button.tsx
@@ -15,7 +15,7 @@ interface Props {
 }
 
 export const ChallengeTryAgainButton = ({ gameState }: Props) => {
-    const { createFromState } = use(GameContext);
+    const { createFromState, isCreatingGame } = use(GameContext);
 
     const { t } = useLingui();
 
@@ -25,13 +25,12 @@ export const ChallengeTryAgainButton = ({ gameState }: Props) => {
 
     return (
         <BlackButton
-            href="/game"
+            icon={LucideRotateCcw}
+            isLoading={isCreatingGame}
             onPress={handleTryAgain}
-            replace
             style={styles.button}
             testID={ChallengeTryAgainButtonSelectors.Root}
             text={t`Try Again`}
-            icon={LucideRotateCcw}
-        ></BlackButton>
+        />
     );
 };

--- a/packages/app/src/game/components/game-provider/game-provider.spec.tsx
+++ b/packages/app/src/game/components/game-provider/game-provider.spec.tsx
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+import { DifficultyEnum, Sudoku, defaultSudokuConfig } from '@suuudokuuu/generator';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import { use } from 'react';
+
+import { GameContext } from '../../context/game.context';
+import { initialGameState } from '../../store/game.state';
+
+import { GameProvider } from './game-provider';
+
+import type { ReactNode } from 'react';
+
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+const mockDispatch = jest.fn();
+const mockAlert = jest.fn();
+
+jest.mock('expo-router', () => ({ useRouter: () => ({ push: mockPush, replace: mockReplace }) }));
+jest.mock('../../../@generic/components/alert/alert', () => ({ Alert: (title: string) => mockAlert(title) }));
+jest.mock('../../../@generic/hooks/use-app-dispatch.hook', () => ({ useAppDispatch: () => mockDispatch }));
+jest.mock('../../../@generic/hooks/use-app-selector.hook', () => ({ useAppSelector: (selector: () => unknown) => selector() }));
+jest.mock('../../store/game.selectors', () => ({ gameSudokuStringSelector: () => '' }));
+jest.mock('../../../settings/store/settings.selectors', () => ({ settingsLanguageSelector: () => 'en' }));
+
+const maxMistakes = 3;
+
+interface Props {
+    readonly children: ReactNode;
+}
+
+const GameProviderWrapper = ({ children }: Props) => (
+    <I18nProvider i18n={i18n}>
+        <GameProvider>{children}</GameProvider>
+    </I18nProvider>
+);
+
+const renderGameContext = () => renderHook(() => use(GameContext), { wrapper: GameProviderWrapper });
+
+const buildChallengeState = () => {
+    const sudoku = new Sudoku(defaultSudokuConfig);
+
+    sudoku.create(DifficultyEnum.Newbie);
+
+    return { ...initialGameState, sudokuString: sudoku.toString() };
+};
+
+describe('GameProvider', () => {
+    let createSpy = jest.spyOn(Sudoku.prototype, 'create');
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        createSpy = jest.spyOn(Sudoku.prototype, 'create');
+    });
+
+    it('should generate, dispatch, and navigate once for repeated create calls', async () => {
+        const { result } = await renderGameContext();
+
+        await act(() => {
+            result.current.create(DifficultyEnum.Newbie, maxMistakes);
+            result.current.create(DifficultyEnum.Newbie, maxMistakes);
+            result.current.create(DifficultyEnum.Newbie, maxMistakes);
+        });
+
+        await waitFor(() => void expect(mockPush).toHaveBeenCalledTimes(1));
+
+        expect(createSpy).toHaveBeenCalledTimes(1);
+        expect(mockDispatch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should report itself as creating before the deferred generation runs', async () => {
+        const { result } = await renderGameContext();
+
+        await act(() => void result.current.create(DifficultyEnum.Newbie, maxMistakes));
+
+        expect(result.current.isCreatingGame).toBe(true);
+        expect(createSpy).not.toHaveBeenCalled();
+
+        await waitFor(() => void expect(result.current.isCreatingGame).toBe(false));
+
+        expect(createSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should load and navigate once for repeated createFromState calls', async () => {
+        const challengeState = buildChallengeState();
+        const { result } = await renderGameContext();
+
+        createSpy.mockClear();
+
+        await act(() => {
+            result.current.createFromState(challengeState);
+            result.current.createFromState(challengeState);
+        });
+
+        await waitFor(() => void expect(mockReplace).toHaveBeenCalledTimes(1));
+
+        expect(mockDispatch).toHaveBeenCalledTimes(2);
+        expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it('should surface the alert and allow a retry when generation fails', async () => {
+        const { result } = await renderGameContext();
+
+        createSpy.mockImplementationOnce(() => {
+            throw new Error('generation failed');
+        });
+
+        await act(() => void result.current.create(DifficultyEnum.Newbie, maxMistakes));
+
+        await waitFor(() => void expect(mockAlert).toHaveBeenCalledTimes(1));
+
+        expect(result.current.isCreatingGame).toBe(false);
+        expect(mockPush).not.toHaveBeenCalled();
+
+        await act(() => void result.current.create(DifficultyEnum.Newbie, maxMistakes));
+
+        await waitFor(() => void expect(mockPush).toHaveBeenCalledTimes(1));
+    });
+});

--- a/packages/app/src/game/components/game-provider/game-provider.tsx
+++ b/packages/app/src/game/components/game-provider/game-provider.tsx
@@ -2,7 +2,7 @@ import { i18n } from '@lingui/core';
 import { useLingui } from '@lingui/react/macro';
 import { Sudoku, defaultSudokuConfig } from '@suuudokuuu/generator';
 import { useRouter } from 'expo-router';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { getErrorMessage, isNotEmptyString } from '@rnw-community/shared';
 
@@ -26,6 +26,9 @@ export const GameProvider = ({ children }: Props) => {
     const dispatch = useAppDispatch();
     const router = useRouter();
     const { t } = useLingui();
+
+    const isCreatingGameRef = useRef(false);
+    const [isCreatingGame, setIsCreatingGame] = useState(false);
 
     const currentGameString = useAppSelector(gameSudokuStringSelector);
     const currentLanguage = useAppSelector(settingsLanguageSelector);
@@ -54,8 +57,30 @@ export const GameProvider = ({ children }: Props) => {
         return new Sudoku(defaultSudokuConfig);
     });
 
-    const createFromState = (newState: GameState) => {
-        try {
+    const runGameCreation = (operation: () => void) => {
+        if (isCreatingGameRef.current) {
+            return;
+        }
+
+        isCreatingGameRef.current = true;
+        setIsCreatingGame(true);
+
+        requestAnimationFrame(() =>
+            requestAnimationFrame(() => {
+                try {
+                    operation();
+                } catch (error: unknown) {
+                    showAlert(error);
+                } finally {
+                    isCreatingGameRef.current = false;
+                    setIsCreatingGame(false);
+                }
+            })
+        );
+    };
+
+    const createFromState = (newState: GameState) =>
+        void runGameCreation(() => {
             const needsWallClock = isNotEmptyString(newState.challengeState) || newState.isChallengeRun;
             dispatch(gameLoadAction({ ...newState, ...(needsWallClock && { wallClockStartMs: Date.now() }) }));
 
@@ -64,29 +89,23 @@ export const GameProvider = ({ children }: Props) => {
             dispatch(gameResumeAction());
 
             router.replace('/game');
+        });
 
-            return true;
-        } catch (error) {
-            showAlert(error);
+    const create = (difficulty: DifficultyEnum, maxMistakes: number, isChallengeRun = false) =>
+        void runGameCreation(() => {
+            const newSudoku = new Sudoku(defaultSudokuConfig);
 
-            return false;
-        }
-    };
+            newSudoku.create(difficulty);
+            setSudoku(newSudoku);
 
-    const create = (difficulty: DifficultyEnum, maxMistakes: number, isChallengeRun = false) => {
-        const newSudoku = new Sudoku(defaultSudokuConfig);
-
-        newSudoku.create(difficulty);
-        setSudoku(newSudoku);
-
-        const sudokuString = newSudoku.toString();
-        dispatch(gameStartAction({ maxMistakes, sudokuString, isChallengeRun }));
-        router.push('/game');
-    };
+            const sudokuString = newSudoku.toString();
+            dispatch(gameStartAction({ maxMistakes, sudokuString, isChallengeRun }));
+            router.push('/game');
+        });
 
     useEffect(() => void i18n.activate(currentLanguage), [currentLanguage]);
 
-    const value = { create, createFromState, sudoku };
+    const value = { create, createFromState, isCreatingGame, sudoku };
 
     return <GameContext value={value}>{children}</GameContext>;
 };

--- a/packages/app/src/game/context/game.context.tsx
+++ b/packages/app/src/game/context/game.context.tsx
@@ -8,5 +8,6 @@ import type { GameContextValueInterface } from '../interface/game-context-value.
 export const GameContext = createContext<GameContextValueInterface>({
     create: emptyFn,
     createFromState: emptyFn,
+    isCreatingGame: false,
     sudoku: new Sudoku(defaultSudokuConfig)
 });

--- a/packages/app/src/game/interface/game-context-value.interface.ts
+++ b/packages/app/src/game/interface/game-context-value.interface.ts
@@ -4,5 +4,6 @@ import type { DifficultyEnum, Sudoku } from '@suuudokuuu/generator';
 export interface GameContextValueInterface {
     readonly create: (difficulty: DifficultyEnum, maxMistakes: number, isChallengeRun?: boolean) => void;
     readonly createFromState: (newState: GameState) => void;
+    readonly isCreatingGame: boolean;
     readonly sudoku: Sudoku;
 }

--- a/packages/app/src/screens/components/home-screen/home.screen.tsx
+++ b/packages/app/src/screens/components/home-screen/home.screen.tsx
@@ -3,7 +3,7 @@ import { DifficultyEnum, Sudoku, defaultSudokuConfig } from '@suuudokuuu/generat
 import { ScreenChromeScrollView } from '@suuudokuuu/screen-chrome';
 import { resolveUnistyleForAnimated } from '@suuudokuuu/ui';
 import { Link } from 'expo-router';
-import { use, useState } from 'react';
+import { use } from 'react';
 import { Pressable, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -56,7 +56,7 @@ const topEdgeFadeProps = { height: HomeScreenTopOverlayHeight, intensity: HomeSc
 
 // eslint-disable-next-line max-lines-per-function
 export const HomeScreen = () => {
-    const { create } = use(GameContext);
+    const { create, isCreatingGame } = use(GameContext);
     const { theme } = use(ThemeContext);
     const { t } = useLingui();
     const safeAreaInsets = useSafeAreaInsets();
@@ -70,20 +70,9 @@ export const HomeScreen = () => {
     const isGameStarted = useAppSelector(gameIsStartedSelector);
     const maxMistakes = useAppSelector(settingsLastGameMaxMistakesSelector);
     const isChallengeMode = useAppSelector(settingsLastGameChallengeModeSelector);
-    const [isLoading, setIsLoading] = useState(false);
     const handleDifficultyChange = (newDifficulty: DifficultyEnum) => dispatch(settingsSetAction({ lastGameDifficulty: newDifficulty }));
     const handleMaxMistakes = (newMaxMistakes: number) => () => dispatch(settingsSetAction({ lastGameMaxMistakes: newMaxMistakes }));
-    const startNewPuzzle = () => {
-        setIsLoading(true);
-
-        setTimeout(() => {
-            try {
-                create(difficulty, maxMistakes, isChallengeMode);
-            } finally {
-                setIsLoading(false);
-            }
-        });
-    };
+    const startNewPuzzle = () => void create(difficulty, maxMistakes, isChallengeMode);
 
     const handleStart = () => {
         if (!isGameStarted) {
@@ -256,7 +245,7 @@ export const HomeScreen = () => {
                             currentProgressPercent={currentProgressPercent}
                             currentProgressText={currentProgressText}
                             isGameStarted={isGameStarted}
-                            isLoading={isLoading}
+                            isLoading={isCreatingGame}
                             onStart={handleStart}
                             startButtonSubtitle={setupSummary}
                             startButtonText={startButtonText}

--- a/packages/app/src/screens/components/loser-screen/loser-screen-actions/loser-screen-actions.tsx
+++ b/packages/app/src/screens/components/loser-screen/loser-screen-actions/loser-screen-actions.tsx
@@ -20,7 +20,7 @@ interface Props {
 
 export const LoserScreenActions = ({ difficulty, gameState }: Props) => {
     const { t } = useLingui();
-    const { create } = use(GameContext);
+    const { create, isCreatingGame } = use(GameContext);
 
     const handlePlayAgain = () => void create(difficulty, gameState.maxMistakes);
     const homeAction = <GameResultHomeButton accessibilityLabel={t`Home`} testID={LoserScreenSelectors.BackHomeButton} />;
@@ -29,6 +29,7 @@ export const LoserScreenActions = ({ difficulty, gameState }: Props) => {
         <GameResultActionsLayout homeAction={homeAction}>
             <AppLinkButton
                 icon={LucideRotateCcw}
+                isLoading={isCreatingGame}
                 onPress={handlePlayAgain}
                 size="large"
                 style={styles.primaryButton}

--- a/packages/app/src/screens/components/shared-screen/shared-screen.tsx
+++ b/packages/app/src/screens/components/shared-screen/shared-screen.tsx
@@ -21,7 +21,7 @@ interface Props {
 
 export const SharedScreen = ({ stateString }: Props) => {
     const { t } = useLingui();
-    const { createFromState } = use(GameContext);
+    const { createFromState, isCreatingGame } = use(GameContext);
 
     const { gameState, isReadable, kind } = decodeSharedGameState(stateString);
     const resumeTimeText = useTimerText(gameState.elapsedTime);
@@ -37,7 +37,14 @@ export const SharedScreen = ({ stateString }: Props) => {
     };
 
     if (kind === SharedPayloadKindEnum.Challenge && isNotEmptyString(challengeState)) {
-        return <ChallengeAcceptScreen challengeState={challengeState} onAccept={handleOpenPuzzle} opponentTotalTime={challengeTime} />;
+        return (
+            <ChallengeAcceptScreen
+                challengeState={challengeState}
+                isLoading={isCreatingGame}
+                onAccept={handleOpenPuzzle}
+                opponentTotalTime={challengeTime}
+            />
+        );
     }
 
     const isHandoff = kind === SharedPayloadKindEnum.Handoff;
@@ -54,7 +61,12 @@ export const SharedScreen = ({ stateString }: Props) => {
             </View>
 
             <View style={styles.buttonsWrapper}>
-                <BlackButton onPress={handleOpenPuzzle} testID={SharedScreenSelectors.ConfirmButton} text={confirmText} />
+                <BlackButton
+                    isLoading={isCreatingGame}
+                    onPress={handleOpenPuzzle}
+                    testID={SharedScreenSelectors.ConfirmButton}
+                    text={confirmText}
+                />
                 <BlackButton href="/" text={t`Cancel`} />
             </View>
         </View>

--- a/packages/app/src/screens/components/winner-screen/winner-screen-actions/winner-screen-actions.tsx
+++ b/packages/app/src/screens/components/winner-screen/winner-screen-actions/winner-screen-actions.tsx
@@ -28,7 +28,7 @@ interface Props {
 
 export const WinnerScreenActions = ({ difficulty, gameState }: Props) => {
     const { t } = useLingui();
-    const { create } = use(GameContext);
+    const { create, isCreatingGame } = use(GameContext);
     const { theme } = use(ThemeContext);
 
     const hasRival = isNotEmptyString(gameState.challengeState);
@@ -39,7 +39,12 @@ export const WinnerScreenActions = ({ difficulty, gameState }: Props) => {
 
     if (isChallengeShareable || isPuzzleShareable) {
         const playAgainAction = (
-            <GlassIconButton accessibilityLabel={t`Play again`} onPress={handlePlayAgain} testID={WinnerScreenSelectors.PlayAgainButton}>
+            <GlassIconButton
+                accessibilityLabel={t`Play again`}
+                isLoading={isCreatingGame}
+                onPress={handlePlayAgain}
+                testID={WinnerScreenSelectors.PlayAgainButton}
+            >
                 <LucideRotateCcw color={theme.colors.label.inverted} />
             </GlassIconButton>
         );
@@ -58,7 +63,7 @@ export const WinnerScreenActions = ({ difficulty, gameState }: Props) => {
 
     return (
         <GameResultActionsLayout homeAction={homeAction}>
-            <PlayAgainButton onPress={handlePlayAgain} style={styles.button} />
+            <PlayAgainButton isLoading={isCreatingGame} onPress={handlePlayAgain} style={styles.button} />
         </GameResultActionsLayout>
     );
 };

--- a/packages/app/src/screens/components/winner-screen/winner-screen.spec.ts
+++ b/packages/app/src/screens/components/winner-screen/winner-screen.spec.ts
@@ -70,6 +70,6 @@ describe('WinnerScreen', () => {
     it('starts the same completed-game setup without returning to game setup', () => {
         expect(source).toContain('GameContext');
         expect(source).toContain('create(difficulty, gameState.maxMistakes)');
-        expect(source).toContain('<PlayAgainButton onPress={handlePlayAgain}');
+        expect(source).toContain('<PlayAgainButton isLoading={isCreatingGame} onPress={handlePlayAgain}');
     });
 });

--- a/packages/ui/jest.config.js
+++ b/packages/ui/jest.config.js
@@ -1,8 +1,21 @@
+const path = require('node:path');
+
+const reactNativeRoot = path.dirname(require.resolve('react-native'));
+
 module.exports = {
     coverageReporters: ['text-summary', 'lcov'],
     reporters: ['default'],
+    collectCoverageFrom: ['src/**/*.util.ts'],
     coveragePathIgnorePatterns: ['.mock.ts'],
     displayName: 'ui',
+    haste: {
+        defaultPlatform: 'ios',
+        platforms: ['android', 'ios', 'native']
+    },
+    resolver: require.resolve('@react-native/jest-preset/jest/resolver.js'),
+    moduleNameMapper: {
+        '^react-native($|/.*)': `${reactNativeRoot}/$1`
+    },
     testRegex: './src/.*\\.spec\\.(tsx?)$',
     testEnvironment: 'node',
     coverageThreshold: {
@@ -12,5 +25,14 @@ module.exports = {
             lines: 100,
             functions: 100
         }
-    }
+    },
+    globals: { __DEV__: true },
+    setupFiles: ['@react-native/jest-preset/jest/setup.js', 'react-native-unistyles/mocks', '<rootDir>/jest.setup.ts'],
+    transform: {
+        '^.+\\.(js|jsx|ts|tsx|mjs)$': 'babel-jest',
+        '^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$': require.resolve('@react-native/jest-preset/jest/assetFileTransformer.js')
+    },
+    transformIgnorePatterns: [
+        'node_modules/(?!(react-native|react-native-reanimated|react-native-worklets|@react-native|@testing-library/react-native|test-renderer)/)'
+    ]
 };

--- a/packages/ui/jest.setup.ts
+++ b/packages/ui/jest.setup.ts
@@ -1,0 +1,22 @@
+import { StyleSheet } from 'react-native-unistyles';
+
+import { Breakpoints } from './src/theme/constant/breakpoints.constant';
+import { ContentWidthConstant } from './src/theme/constant/content-width.constant';
+import { DefaultUiTheme } from './src/theme/constant/default-ui-theme.constant';
+import { RadiusConstant } from './src/theme/constant/radius.constant';
+import { SpacingConstant } from './src/theme/constant/spacing.constant';
+import { TypographyConstant } from './src/theme/constant/typography.constant';
+
+StyleSheet.configure({
+    breakpoints: Breakpoints,
+    settings: { adaptiveThemes: false, initialTheme: 'default' },
+    themes: {
+        default: {
+            colors: DefaultUiTheme.colors,
+            contentWidth: ContentWidthConstant,
+            radius: RadiusConstant,
+            spacing: SpacingConstant,
+            typography: TypographyConstant
+        }
+    }
+});

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -37,6 +37,9 @@
     "dependencies": {
         "@rnw-community/shared": "^2.2.0"
     },
+    "devDependencies": {
+        "@testing-library/react-native": "^14.0.1"
+    },
     "peerDependencies": {
         "lucide-react-native": "^1.21.0",
         "react": "19.2.3",

--- a/packages/ui/src/components/app-button/app-button.spec.tsx
+++ b/packages/ui/src/components/app-button/app-button.spec.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+
+import { AppButton } from './app-button';
+import { AppButtonLoaderTestId } from './constant/app-button-loader-test-id.constant';
+
+const buttonTestId = 'app-button';
+
+describe('AppButton', () => {
+    it('should render the loader instead of the text while loading', async () => {
+        await render(<AppButton isLoading testID={buttonTestId} text="Start puzzle" />);
+
+        expect(screen.getByTestId(AppButtonLoaderTestId)).toBeTruthy();
+        expect(screen.queryByText('Start puzzle')).toBeNull();
+    });
+
+    it('should expose busy and disabled accessibility state while loading', async () => {
+        await render(<AppButton isLoading testID={buttonTestId} text="Start puzzle" />);
+
+        expect(screen.getByTestId(buttonTestId)).toBeBusy();
+        expect(screen.getByTestId(buttonTestId)).toBeDisabled();
+    });
+
+    it('should ignore presses while loading', async () => {
+        const handlePress = jest.fn();
+
+        await render(<AppButton isLoading onPress={handlePress} testID={buttonTestId} text="Start puzzle" />);
+        await fireEvent.press(screen.getByTestId(buttonTestId));
+
+        expect(handlePress).not.toHaveBeenCalled();
+    });
+
+    it('should invoke onPress when it is neither loading nor disabled', async () => {
+        const handlePress = jest.fn();
+
+        await render(<AppButton onPress={handlePress} testID={buttonTestId} text="Start puzzle" />);
+        await fireEvent.press(screen.getByTestId(buttonTestId));
+
+        expect(handlePress).toHaveBeenCalledTimes(1);
+    });
+
+    it('should stay disabled without a loader when disabled is passed explicitly', async () => {
+        const handlePress = jest.fn();
+
+        await render(<AppButton disabled onPress={handlePress} testID={buttonTestId} text="Start puzzle" />);
+        await fireEvent.press(screen.getByTestId(buttonTestId));
+
+        expect(screen.getByText('Start puzzle')).toBeTruthy();
+        expect(screen.getByTestId(buttonTestId)).toBeDisabled();
+        expect(screen.getByTestId(buttonTestId)).not.toBeBusy();
+        expect(handlePress).not.toHaveBeenCalled();
+    });
+});

--- a/packages/ui/src/components/app-button/app-button.tsx
+++ b/packages/ui/src/components/app-button/app-button.tsx
@@ -5,6 +5,7 @@ import { isDefined, isNotEmptyString } from '@rnw-community/shared';
 
 import { AppButtonStyles as styles } from './app-button.styles';
 import { AppButtonDefaultIconSize } from './constant/app-button-default-icon-size.constant';
+import { AppButtonLoaderTestId } from './constant/app-button-loader-test-id.constant';
 import { type AppButtonVariant, appButtonGetColors } from './utils/app-button-get-colors.util';
 
 import type { LucideIcon } from 'lucide-react-native';
@@ -31,6 +32,7 @@ export const AppButton = ({
     onPress,
     iconSize = AppButtonDefaultIconSize,
     isLoading = false,
+    disabled,
     icon: Icon,
     children,
     size = 'regular',
@@ -49,10 +51,12 @@ export const AppButton = ({
     }
     const textStyles = [styles.text, textSizeStyles, { color: colors.textColor }, textStyle];
     const shouldShowText = isNotEmptyString(text);
+    const isDisabled = isLoading || disabled === true;
+    const accessibilityState = { busy: isLoading, disabled: isDisabled };
 
     return (
-        <Pressable onPress={onPress} style={buttonStyles} {...restProps}>
-            {isLoading && <ActivityIndicator color={colors.textColor} />}
+        <Pressable onPress={onPress} style={buttonStyles} {...restProps} accessibilityState={accessibilityState} disabled={isDisabled}>
+            {isLoading && <ActivityIndicator color={colors.textColor} testID={AppButtonLoaderTestId} />}
 
             {!isLoading && isDefined(children) && children}
 

--- a/packages/ui/src/components/app-button/constant/app-button-loader-test-id.constant.ts
+++ b/packages/ui/src/components/app-button/constant/app-button-loader-test-id.constant.ts
@@ -1,0 +1,1 @@
+export const AppButtonLoaderTestId = 'AppButtonSelectors.Loader';

--- a/tests/app-tests/config.yaml
+++ b/tests/app-tests/config.yaml
@@ -21,3 +21,4 @@ executionOrder:
         - 08.challenge-accept-preview.flow
         - 09.challenge-mode-run.flow
         - 10.challenge-recording-summary.flow
+        - 11.single-flight-start.flow

--- a/tests/app-tests/flows/11.single-flight-start.flow.yaml
+++ b/tests/app-tests/flows/11.single-flight-start.flow.yaml
@@ -1,0 +1,22 @@
+appId: ${APP_ID}
+---
+- startRecording:
+      path: '11.single-flight-start'
+      optional: true
+
+- runFlow: subflows/navigation/launch-home.flow.yaml
+- scrollUntilVisible:
+      element:
+          id: 'HomeScreenSelectors.StartButton'
+      direction: DOWN
+      timeout: 3000
+- tapOn:
+      id: 'HomeScreenSelectors.StartButton'
+      repeat: 5
+      delay: 50
+- extendedWaitUntil:
+      visible:
+          id: 'GameScreenSelectors.Root'
+      timeout: 15000
+- runFlow: subflows/game/quit-current-game.flow.yaml
+- stopApp

--- a/yarn.lock
+++ b/yarn.lock
@@ -5025,6 +5025,7 @@ __metadata:
   resolution: "@suuudokuuu/ui@workspace:packages/ui"
   dependencies:
     "@rnw-community/shared": "npm:^2.2.0"
+    "@testing-library/react-native": "npm:^14.0.1"
   peerDependencies:
     lucide-react-native: ^1.21.0
     react: 19.2.3


### PR DESCRIPTION
Closes #224

## Problem

Game-generation buttons accepted repeated presses while a puzzle was being generated. Three defects compounded:

1. `GameProvider.create` had no in-flight guard — every call generated a Sudoku and pushed `/game`.
2. `HomeScreen` owned a local `isLoading` flag and deferred generation with a bare `setTimeout`, so several callbacks could queue before the loading render committed.
3. `AppButton` swapped its content for an `ActivityIndicator` but left the `Pressable` interactive and exposed no busy/disabled state.

Separately, `ChallengeTryAgainButton` passed `href="/game"` with `replace` *and* called `createFromState`, which already replaces — restart navigation had two owners.

## Approach

`GameProvider` routes both `create` and `createFromState` through one `runGameCreation` guard:

- A `useRef` boolean is the ownership claim, read and written synchronously, so a second press in the same tick — or any tick before the operation finishes — returns immediately. `setState` is batched and cannot serve this role.
- A `useState` boolean is the render signal, exposed as `isCreatingGame` on `GameContext`. One shared flag, not per-screen flags.
- The operation is deferred with nested `requestAnimationFrame`: the outer frame runs after React commits the pending render, the inner one after that commit reaches the screen. A single `setTimeout(fn, 0)` yields only one macrotask and does not guarantee the loader painted before the JS thread blocks.
- `try`/`catch`/`finally` routes failures to the existing localized alert and always releases the claim. `create` previously had no `catch` at all, so a throwing `Sudoku.create` was unhandled.

The claim is released in `finally` rather than on unmount: `GameProvider` sits above the router and `HomeScreen` stays mounted under the tab layout, so an unmount-only release would leave Home's start button spinning forever after a successful start.

`AppButton` now treats `isLoading` as non-interactive — `disabled` on the `Pressable` plus `accessibilityState={{ busy, disabled }}` — which removes tap-through for every button reached through `AppLinkButton`, `BlackButton`, `BlackIconButton`, and `GlassIconButton`.

## Consumers

Home (local `isLoading` and `setTimeout` deleted), loser actions, winner actions (both layouts), `PlayAgainButton`, and challenge try-again read the shared flag. Two more not listed in the issue had the same race and are included: `SharedScreen` and the challenge accept button, both of which reach `createFromState`.

Continue, Home, and Share controls are untouched, per the issue's non-goals.

## Tests

`packages/ui` gains React Native render-test support (resolver, transform, Unistyles setup), with `collectCoverageFrom` pinned to `src/**/*.util.ts` so the existing 100% thresholds keep the scope they effectively had.

- `app-button.spec.tsx` — `isLoading` renders the loader and hides the text, reports busy and disabled, and does not invoke `onPress`; an explicit `disabled` still disables without a loader. Verified failing (3/5) before the fix.
- `game-provider.spec.tsx` — three rapid `create` calls produce one `Sudoku.create`, one dispatch, and one `router.push`; `isCreatingGame` is `true` before the deferred generation and `false` after; two rapid `createFromState` calls produce one `router.replace`; a generation failure surfaces the alert, clears the flag, and permits a retry that navigates once. Verified failing (4/4) before the fix.
- `11.single-flight-start.flow.yaml` — rapid taps on Home's start button, then quit back to Home.

Not written: per-screen specs asserting `isLoading={isCreatingGame}` is passed through. Four near-identical render tests would assert a type-checked prop hand-off already covered above. `winner-screen.spec.ts` pins that exact JSX as source text and was updated.

## Known limitation

The Maestro flow cannot count navigation-stack depth. `GameScreen.handleExit` uses `router.dismissTo`, which collapses the whole stack, so one quit lands on Home whether one or two game screens were pushed, and Maestro has no cross-platform back key. The flow guards against rapid-tap breakage and hangs; the exactly-once guarantee is enforced by `game-provider.spec.tsx`. The flow has not been run on a device yet.

## Verification

`yarn format && yarn ts && yarn lint && yarn deadcode && yarn cpd` clean (2 pre-existing warnings in `unistyles.config.ts`). `yarn test` 958 passing, `yarn test:coverage` within thresholds, `yarn i18n:check` clean — no user-facing strings changed.