### PR TITLE
fix(app): use explicit ESM import extensions in Vercel beta functions

### DIFF
--- a/packages/app/jest.config.js
+++ b/packages/app/jest.config.js
@@ -24,7 +24,8 @@ module.exports = {
             '<rootDir>/../ui/src/components/app-metric-strip/utils/app-metric-strip-get-colors.util.ts',
         '^@suuudokuuu/ui/app-toggle-get-colors$': '<rootDir>/../ui/src/components/app-toggle/utils/app-toggle-get-colors.util.ts',
         '^react-native-reanimated$': '<rootDir>/src/@generic/mocks/react-native-reanimated.mock.tsx',
-        '^react-native($|/.*)': `${reactNativeRoot}/$1`
+        '^react-native($|/.*)': `${reactNativeRoot}/$1`,
+        '^(\\.{1,2}/.*)\\.js$': '$1'
     },
     testRegex: './(?:src|vercel-functions)/.*\\.spec\\.(tsx?)$',
     testEnvironment: 'node',

--- a/packages/app/vercel-functions/api/beta/apk.ts
+++ b/packages/app/vercel-functions/api/beta/apk.ts
@@ -1,4 +1,4 @@
-import { createBetaHandler } from '../../shared/create-beta-handler.util';
+import { createBetaHandler } from '../../shared/create-beta-handler.util.js';
 
 const handler = createBetaHandler('apk');
 

--- a/packages/app/vercel-functions/api/beta/ipa.ts
+++ b/packages/app/vercel-functions/api/beta/ipa.ts
@@ -1,4 +1,4 @@
-import { createBetaHandler } from '../../shared/create-beta-handler.util';
+import { createBetaHandler } from '../../shared/create-beta-handler.util.js';
 
 const handler = createBetaHandler('ipa');
 

--- a/packages/app/vercel-functions/api/beta/manifest.ts
+++ b/packages/app/vercel-functions/api/beta/manifest.ts
@@ -1,4 +1,4 @@
-import { createBetaHandler } from '../../shared/create-beta-handler.util';
+import { createBetaHandler } from '../../shared/create-beta-handler.util.js';
 
 const handler = createBetaHandler('manifest');
 

--- a/packages/app/vercel-functions/api/beta/release.ts
+++ b/packages/app/vercel-functions/api/beta/release.ts
@@ -1,4 +1,4 @@
-import { createBetaHandler } from '../../shared/create-beta-handler.util';
+import { createBetaHandler } from '../../shared/create-beta-handler.util.js';
 
 const handler = createBetaHandler('release');
 

--- a/packages/app/vercel-functions/shared/beta-response.util.ts
+++ b/packages/app/vercel-functions/shared/beta-response.util.ts
@@ -4,7 +4,7 @@ import {
     BetaXmlContentType,
     HttpFoundStatus,
     HttpOkStatus
-} from './beta-release.constant';
+} from './beta-release.constant.js';
 
 const NoStoreCacheControl = 'no-store';
 const SuccessCacheControl = 'no-cache';

--- a/packages/app/vercel-functions/shared/create-beta-handler.util.spec.ts
+++ b/packages/app/vercel-functions/shared/create-beta-handler.util.spec.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, jest } from '@jest/globals';
 
-import apkRoute from '../api/beta/apk';
-import ipaRoute from '../api/beta/ipa';
-import manifestRoute from '../api/beta/manifest';
-import releaseRoute from '../api/beta/release';
+import apkRoute from '../api/beta/apk.js';
+import ipaRoute from '../api/beta/ipa.js';
+import manifestRoute from '../api/beta/manifest.js';
+import releaseRoute from '../api/beta/release.js';
 
 import {
     GithubReleasesTokenEnvironmentVariable,
@@ -12,10 +12,10 @@ import {
     HttpMethodNotAllowedStatus,
     HttpNotFoundStatus,
     HttpOkStatus
-} from './beta-release.constant';
-import { createBetaHandler, resolveBetaReleaseFromEnvironment } from './create-beta-handler.util';
+} from './beta-release.constant.js';
+import { createBetaHandler, resolveBetaReleaseFromEnvironment } from './create-beta-handler.util.js';
 
-import type { BetaRelease, ResolveBetaReleaseResult } from './beta-release.interface';
+import type { BetaRelease, ResolveBetaReleaseResult } from './beta-release.interface.js';
 
 const CommitSha = '0123456789abcdef0123456789abcdef01234567';
 const ChecksumLength = 64;

--- a/packages/app/vercel-functions/shared/create-beta-handler.util.ts
+++ b/packages/app/vercel-functions/shared/create-beta-handler.util.ts
@@ -9,12 +9,12 @@ import {
     HttpMethodNotAllowedStatus,
     HttpNotFoundStatus,
     HttpOkStatus
-} from './beta-release.constant';
-import { createBetaHeadResponse, createBetaJsonResponse, createBetaRedirectResponse, createBetaXmlResponse } from './beta-response.util';
-import { resolveBetaRelease } from './resolve-beta-release.util';
-import { serializeOtaManifest } from './serialize-ota-manifest.util';
+} from './beta-release.constant.js';
+import { createBetaHeadResponse, createBetaJsonResponse, createBetaRedirectResponse, createBetaXmlResponse } from './beta-response.util.js';
+import { resolveBetaRelease } from './resolve-beta-release.util.js';
+import { serializeOtaManifest } from './serialize-ota-manifest.util.js';
 
-import type { BetaRelease, ResolveBetaReleaseResult } from './beta-release.interface';
+import type { BetaRelease, ResolveBetaReleaseResult } from './beta-release.interface.js';
 
 type BetaEndpointKind = 'release' | 'ipa' | 'apk' | 'manifest';
 type BetaReleaseResolver = () => Promise<ResolveBetaReleaseResult>;

--- a/packages/app/vercel-functions/shared/parse-checksums.util.spec.ts
+++ b/packages/app/vercel-functions/shared/parse-checksums.util.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { MaximumChecksumsByteLength } from './beta-release.constant';
-import { parseChecksums } from './parse-checksums.util';
+import { MaximumChecksumsByteLength } from './beta-release.constant.js';
+import { parseChecksums } from './parse-checksums.util.js';
 
 const ChecksumLength = 64;
 const IpaChecksum = 'a'.repeat(ChecksumLength);

--- a/packages/app/vercel-functions/shared/parse-checksums.util.ts
+++ b/packages/app/vercel-functions/shared/parse-checksums.util.ts
@@ -1,6 +1,6 @@
-import { MaximumChecksumsByteLength } from './beta-release.constant';
+import { MaximumChecksumsByteLength } from './beta-release.constant.js';
 
-import type { ReleaseChecksums } from './beta-release.interface';
+import type { ReleaseChecksums } from './beta-release.interface.js';
 
 const ChecksumsPattern = /^([a-f0-9]{64}) {2}suuudokuuu-development\.ipa\n([a-f0-9]{64}) {2}suuudokuuu-development\.apk\n$/u;
 

--- a/packages/app/vercel-functions/shared/parse-release-metadata.util.spec.ts
+++ b/packages/app/vercel-functions/shared/parse-release-metadata.util.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { parseReleaseMetadata } from './parse-release-metadata.util';
+import { parseReleaseMetadata } from './parse-release-metadata.util.js';
 
 const ValidMetadata = {
     branch: 'main',

--- a/packages/app/vercel-functions/shared/parse-release-metadata.util.ts
+++ b/packages/app/vercel-functions/shared/parse-release-metadata.util.ts
@@ -1,7 +1,7 @@
-import { DevelopmentMetadataMarkerPrefix } from './beta-release.constant';
-import { releaseMetadataSchema } from './release-metadata.schema';
+import { DevelopmentMetadataMarkerPrefix } from './beta-release.constant.js';
+import { releaseMetadataSchema } from './release-metadata.schema.js';
 
-import type { ParsedReleaseMetadata } from './beta-release.interface';
+import type { ParsedReleaseMetadata } from './beta-release.interface.js';
 
 const MetadataMarkerPattern = /^<!-- suuudokuuu-development-metadata (.+?) -->/u;
 

--- a/packages/app/vercel-functions/shared/read-bounded-response-text.util.spec.ts
+++ b/packages/app/vercel-functions/shared/read-bounded-response-text.util.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, jest } from '@jest/globals';
 
-import { MaximumChecksumsByteLength } from './beta-release.constant';
-import { readBoundedResponseText } from './read-bounded-response-text.util';
+import { MaximumChecksumsByteLength } from './beta-release.constant.js';
+import { readBoundedResponseText } from './read-bounded-response-text.util.js';
 
 const ChecksumLength = 64;
 const IpaChecksum = 'a'.repeat(ChecksumLength);

--- a/packages/app/vercel-functions/shared/resolve-beta-release.util.spec.ts
+++ b/packages/app/vercel-functions/shared/resolve-beta-release.util.spec.ts
@@ -6,8 +6,8 @@ import {
     DevelopmentIpaAssetName,
     DevelopmentReleaseApiUrl,
     MaximumChecksumsByteLength
-} from './beta-release.constant';
-import { resolveBetaRelease } from './resolve-beta-release.util';
+} from './beta-release.constant.js';
+import { resolveBetaRelease } from './resolve-beta-release.util.js';
 
 const ChecksumLength = 64;
 const IpaChecksum = 'a'.repeat(ChecksumLength);

--- a/packages/app/vercel-functions/shared/resolve-beta-release.util.ts
+++ b/packages/app/vercel-functions/shared/resolve-beta-release.util.ts
@@ -4,10 +4,10 @@ import {
     MaximumChecksumsByteLength,
     MaximumGithubReleasesByteLength,
     UpstreamRequestTimeoutMilliseconds
-} from './beta-release.constant';
-import { parseChecksums } from './parse-checksums.util';
-import { readBoundedResponseText } from './read-bounded-response-text.util';
-import { parseBetaReleaseCandidates } from './select-beta-release.util';
+} from './beta-release.constant.js';
+import { parseChecksums } from './parse-checksums.util.js';
+import { readBoundedResponseText } from './read-bounded-response-text.util.js';
+import { parseBetaReleaseCandidates } from './select-beta-release.util.js';
 
 import type {
     BetaRelease,
@@ -15,7 +15,7 @@ import type {
     ReleaseChecksums,
     ResolveBetaReleaseDependencies,
     ResolveBetaReleaseResult
-} from './beta-release.interface';
+} from './beta-release.interface.js';
 
 type GithubReleasesRequestResult = { readonly input: unknown; readonly status: 'success' } | { readonly status: 'failure' };
 

--- a/packages/app/vercel-functions/shared/select-beta-release.util.spec.ts
+++ b/packages/app/vercel-functions/shared/select-beta-release.util.spec.ts
@@ -5,8 +5,8 @@ import {
     DevelopmentChecksumsAssetName,
     DevelopmentIpaAssetName,
     MaximumChecksumsByteLength
-} from './beta-release.constant';
-import { parseBetaReleaseCandidates, selectBetaReleaseCandidates } from './select-beta-release.util';
+} from './beta-release.constant.js';
+import { parseBetaReleaseCandidates, selectBetaReleaseCandidates } from './select-beta-release.util.js';
 
 const CommitSha = '0123456789abcdef0123456789abcdef01234567';
 const PublishedAt = '2026-07-14T10:30:00Z';

--- a/packages/app/vercel-functions/shared/select-beta-release.util.ts
+++ b/packages/app/vercel-functions/shared/select-beta-release.util.ts
@@ -5,13 +5,13 @@ import {
     DevelopmentReleaseAssetNames,
     DevelopmentReleaseTagPattern,
     MaximumChecksumsByteLength
-} from './beta-release.constant';
-import { githubReleaseSchema, githubReleasesSchema } from './github-release.schema';
-import { parseReleaseMetadata } from './parse-release-metadata.util';
-import { validateReleaseAssetUrl } from './validate-release-asset-url.util';
+} from './beta-release.constant.js';
+import { githubReleaseSchema, githubReleasesSchema } from './github-release.schema.js';
+import { parseReleaseMetadata } from './parse-release-metadata.util.js';
+import { validateReleaseAssetUrl } from './validate-release-asset-url.util.js';
 
-import type { BetaReleaseCandidate } from './beta-release.interface';
-import type { GithubRelease, GithubReleaseAsset } from './github-release.schema';
+import type { BetaReleaseCandidate } from './beta-release.interface.js';
+import type { GithubRelease, GithubReleaseAsset } from './github-release.schema.js';
 
 interface NumberedBetaReleaseCandidate {
     readonly artifactAttempt: number;

--- a/packages/app/vercel-functions/shared/serialize-ota-manifest.util.ts
+++ b/packages/app/vercel-functions/shared/serialize-ota-manifest.util.ts
@@ -1,4 +1,4 @@
-import type { BetaRelease } from './beta-release.interface';
+import type { BetaRelease } from './beta-release.interface.js';
 
 const DevelopmentAppTitle = ''.concat('suuudokuuu', ' ', '(', 'D', 'ev', ')');
 const XmlDeclaration = ''.concat('<?', 'xml', ' ', 'version="1.0"', ' ', 'encoding="UTF-8"', '?>');

--- a/packages/app/vercel-functions/shared/validate-release-asset-url.util.spec.ts
+++ b/packages/app/vercel-functions/shared/validate-release-asset-url.util.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { DevelopmentIpaAssetName } from './beta-release.constant';
-import { validateReleaseAssetUrl } from './validate-release-asset-url.util';
+import { DevelopmentIpaAssetName } from './beta-release.constant.js';
+import { validateReleaseAssetUrl } from './validate-release-asset-url.util.js';
 
 const TagName = 'development-123-1-1';
 const ValidUrl = 'https://github.com/vitalyiegorov/suuudokuuu/releases/download/development-123-1-1/suuudokuuu-development.ipa';

--- a/packages/app/vercel-functions/shared/validate-release-asset-url.util.ts
+++ b/packages/app/vercel-functions/shared/validate-release-asset-url.util.ts
@@ -1,4 +1,4 @@
-import { DevelopmentReleaseAssetNames, DevelopmentReleaseTagPattern } from './beta-release.constant';
+import { DevelopmentReleaseAssetNames, DevelopmentReleaseTagPattern } from './beta-release.constant.js';
 
 const ReleaseDownloadUrlPrefix = 'https://github.com/vitalyiegorov/suuudokuuu/releases/download/';
 const AllowedAssetNames = new Set<string>(DevelopmentReleaseAssetNames);


### PR DESCRIPTION
## Problem

https://suuudokuuu.com/beta shows "Development build unavailable" because every `/api/beta/*` endpoint returns 500 `FUNCTION_INVOCATION_FAILED`.

Vercel production runtime logs show the functions crashing at cold start:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/var/task/shared/create-beta-handler.util'
imported from /var/task/api/beta/release.js
```

## Root cause

`packages/app/vercel-functions/package.json` declares `"type": "module"`, so the deployed functions run as Node ES modules. Vercel transpiles each `.ts` file to `.js` individually and preserves import specifiers verbatim, and all relative imports were extensionless. Node's ESM loader requires exact specifiers with file extensions, so module resolution fails before the handler ever runs. The endpoints have never cold-started successfully since they became serverless functions: `tsc` (`moduleResolution: bundler`) and Jest both tolerate extensionless imports, so CI never caught it.

## Fix

- Add explicit `.js` extensions to every relative import specifier in `packages/app/vercel-functions` (including `import type` and spec files).
- Add a Jest `moduleNameMapper` entry (`'^(\\.{1,2}/.*)\\.js$': '$1'`) so the specs keep resolving the TypeScript sources.

## Validation

- Reproduced the exact production failure locally by transpiling each function per-file with esbuild (`--format=esm`, matching Vercel's compile model) and importing the entrypoints under Node 22: all four failed with the identical `ERR_MODULE_NOT_FOUND` before the fix and load successfully after it.
- `yarn format && yarn ts && yarn lint && yarn deadcode && yarn cpd` clean.
- `yarn test`: 122 suites / 699 tests pass, including all 139 vercel-functions specs.