### PR TITLE
feat(app): celebrate game wins with a reanimated CSS confetti burst

### DIFF
--- a/packages/app/src/app/_layout.tsx
+++ b/packages/app/src/app/_layout.tsx
@@ -10,6 +10,7 @@ import { isDefined } from '@rnw-community/shared';
 import { LinguiDefaultComponent } from '../@generic/components/lingui-default-component/lingui-default-component';
 import { RootProviders } from '../@generic/components/root-providers/root-providers';
 import { i18nGetOSLocale } from '../@generic/utils/i18n.util';
+import { WinConfettiProvider } from '../confetti/components/win-confetti-provider/win-confetti-provider';
 import { GameProvider } from '../game/components/game-provider/game-provider';
 import { ThemeProvider } from '../theme/components/theme-provider/theme-provider';
 
@@ -42,10 +43,12 @@ export default function RootLayout() {
             <ThemeProvider>
                 <I18nProvider i18n={i18n} defaultComponent={LinguiDefaultComponent}>
                     <GameProvider>
-                        <Stack screenOptions={stackOptions}>
-                            <Stack.Screen name="game" options={gameOptions} />
-                            <Stack.Screen name="settings/[setting]" options={settingsOptionSheetOptions} />
-                        </Stack>
+                        <WinConfettiProvider>
+                            <Stack screenOptions={stackOptions}>
+                                <Stack.Screen name="game" options={gameOptions} />
+                                <Stack.Screen name="settings/[setting]" options={settingsOptionSheetOptions} />
+                            </Stack>
+                        </WinConfettiProvider>
                     </GameProvider>
                 </I18nProvider>
             </ThemeProvider>

--- a/packages/app/src/challenge/components/challenge-screenshot-recorder/challenge-screenshot-recorder.web.tsx
+++ b/packages/app/src/challenge/components/challenge-screenshot-recorder/challenge-screenshot-recorder.web.tsx
@@ -1,0 +1,1 @@
+export const ChallengeScreenshotRecorder = () => null;

--- a/packages/app/src/confetti/components/confetti-burst/confetti-burst.styles.ts
+++ b/packages/app/src/confetti/components/confetti-burst/confetti-burst.styles.ts
@@ -1,0 +1,8 @@
+import { StyleSheet } from 'react-native';
+
+export const ConfettiBurstStyles = StyleSheet.create({
+    overlay: {
+        pointerEvents: 'none',
+        zIndex: 1000
+    }
+});

--- a/packages/app/src/confetti/components/confetti-burst/confetti-burst.tsx
+++ b/packages/app/src/confetti/components/confetti-burst/confetti-burst.tsx
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+import { StyleSheet, View, useWindowDimensions } from 'react-native';
+
+import { winConfettiParticleAmountConstant } from '../../constants/win-confetti.constant';
+import { createConfettiParticles } from '../../utils/create-confetti-particles.util';
+import { ConfettiPiece } from '../confetti-piece/confetti-piece';
+
+import { ConfettiBurstStyles as styles } from './confetti-burst.styles';
+
+export const ConfettiBurst = () => {
+    const { height: screenHeight, width: screenWidth } = useWindowDimensions();
+
+    const [particles] = useState(() => createConfettiParticles(winConfettiParticleAmountConstant));
+    const overlayStyle = [StyleSheet.absoluteFill, styles.overlay];
+
+    return (
+        <View style={overlayStyle}>
+            {particles.map(particle => (
+                <ConfettiPiece key={particle.id} particle={particle} screenHeight={screenHeight} screenWidth={screenWidth} />
+            ))}
+        </View>
+    );
+};

--- a/packages/app/src/confetti/components/confetti-piece/confetti-piece.styles.ts
+++ b/packages/app/src/confetti/components/confetti-piece/confetti-piece.styles.ts
@@ -1,0 +1,9 @@
+import { StyleSheet } from 'react-native';
+
+export const ConfettiPieceStyles = StyleSheet.create({
+    piece: {
+        borderRadius: 1,
+        position: 'absolute',
+        top: 0
+    }
+});

--- a/packages/app/src/confetti/components/confetti-piece/confetti-piece.tsx
+++ b/packages/app/src/confetti/components/confetti-piece/confetti-piece.tsx
@@ -1,0 +1,33 @@
+import Reanimated from 'react-native-reanimated';
+
+import { createConfettiPieceKeyframes } from '../../utils/create-confetti-piece-keyframes.util';
+
+import { ConfettiPieceStyles as styles } from './confetti-piece.styles';
+
+import type { ConfettiParticleInterface } from '../../interfaces/confetti-particle.interface';
+import type { ViewStyle } from 'react-native';
+import type { CSSStyle } from 'react-native-reanimated';
+
+interface Props {
+    readonly particle: ConfettiParticleInterface;
+    readonly screenHeight: number;
+    readonly screenWidth: number;
+}
+
+export const ConfettiPiece = ({ particle, screenHeight, screenWidth }: Props) => {
+    const keyframes = createConfettiPieceKeyframes(particle, screenHeight);
+    const pieceStyle: CSSStyle<ViewStyle> = {
+        ...styles.piece,
+        animationDelay: particle.delayMilliseconds,
+        animationDuration: particle.durationMilliseconds,
+        animationFillMode: 'both',
+        animationName: keyframes,
+        animationTimingFunction: 'ease-in',
+        backgroundColor: particle.color,
+        height: particle.size * particle.aspectRatio,
+        left: particle.leftRatio * screenWidth,
+        width: particle.size
+    };
+
+    return <Reanimated.View style={pieceStyle} />;
+};

--- a/packages/app/src/confetti/components/win-confetti-provider/win-confetti-provider.tsx
+++ b/packages/app/src/confetti/components/win-confetti-provider/win-confetti-provider.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useRef, useState } from 'react';
+
+import { isDefined } from '@rnw-community/shared';
+
+import { winConfettiCelebrationDurationConstant } from '../../constants/win-confetti.constant';
+import { WinConfettiContext } from '../../context/win-confetti.context';
+import { ConfettiBurst } from '../confetti-burst/confetti-burst';
+
+import type { ReactNode } from 'react';
+
+interface Props {
+    readonly children: ReactNode;
+}
+
+export const WinConfettiProvider = ({ children }: Props) => {
+    const [isCelebrating, setIsCelebrating] = useState(false);
+
+    const celebrationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const handleCelebrationStart = () => {
+        if (isDefined(celebrationTimeoutRef.current)) {
+            clearTimeout(celebrationTimeoutRef.current);
+        }
+
+        setIsCelebrating(true);
+
+        celebrationTimeoutRef.current = setTimeout(() => void setIsCelebrating(false), winConfettiCelebrationDurationConstant * 1000);
+    };
+
+    useEffect(
+        () => () => {
+            if (isDefined(celebrationTimeoutRef.current)) {
+                clearTimeout(celebrationTimeoutRef.current);
+            }
+        },
+        []
+    );
+
+    const confettiOverlay = isCelebrating ? <ConfettiBurst /> : null;
+
+    return (
+        <WinConfettiContext.Provider value={handleCelebrationStart}>
+            {children}
+            {confettiOverlay}
+        </WinConfettiContext.Provider>
+    );
+};

--- a/packages/app/src/confetti/constants/win-confetti.constant.ts
+++ b/packages/app/src/confetti/constants/win-confetti.constant.ts
@@ -1,0 +1,13 @@
+export const winConfettiParticleAmountConstant = 250;
+export const winConfettiCelebrationDurationConstant = 5;
+
+export const winConfettiPaletteConstant: readonly string[] = [
+    '#f94144',
+    '#f3722c',
+    '#f9c74f',
+    '#90be6d',
+    '#43aa8b',
+    '#4d908e',
+    '#577590',
+    '#f9844a'
+];

--- a/packages/app/src/confetti/context/win-confetti.context.ts
+++ b/packages/app/src/confetti/context/win-confetti.context.ts
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+import { emptyFn } from '@rnw-community/shared';
+
+export const WinConfettiContext = createContext<() => void>(emptyFn);

--- a/packages/app/src/confetti/interfaces/confetti-particle.interface.ts
+++ b/packages/app/src/confetti/interfaces/confetti-particle.interface.ts
@@ -1,0 +1,13 @@
+export interface ConfettiParticleInterface {
+    readonly id: number;
+    readonly leftRatio: number;
+    readonly size: number;
+    readonly aspectRatio: number;
+    readonly color: string;
+    readonly durationMilliseconds: number;
+    readonly delayMilliseconds: number;
+    readonly horizontalDrift: number;
+    readonly swayAmplitude: number;
+    readonly spinDegrees: number;
+    readonly flipDegrees: number;
+}

--- a/packages/app/src/confetti/utils/create-confetti-particles.util.spec.ts
+++ b/packages/app/src/confetti/utils/create-confetti-particles.util.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { winConfettiCelebrationDurationConstant, winConfettiPaletteConstant } from '../constants/win-confetti.constant';
+
+import { createConfettiParticles } from './create-confetti-particles.util';
+
+const MinSize = 6;
+const MaxSize = 12;
+const MinAspectRatio = 0.4;
+const MaxAspectRatio = 1;
+const MinHorizontalDrift = -60;
+const MaxHorizontalDrift = 60;
+const MinSwayAmplitude = 10;
+const MaxSwayAmplitude = 40;
+const MinRotationDegrees = 360;
+const MaxRotationDegrees = 1080;
+
+describe('createConfettiParticles', () => {
+    const particles = createConfettiParticles(500);
+
+    it('creates the requested amount of particles with unique ids', () => {
+        expect(particles).toHaveLength(500);
+        expect(new Set(particles.map(particle => particle.id)).size).toBe(500);
+    });
+
+    it('keeps every particle within the configured ranges', () => {
+        for (const particle of particles) {
+            expect(particle.leftRatio).toBeGreaterThanOrEqual(0);
+            expect(particle.leftRatio).toBeLessThanOrEqual(1);
+            expect(particle.size).toBeGreaterThanOrEqual(MinSize);
+            expect(particle.size).toBeLessThanOrEqual(MaxSize);
+            expect(particle.aspectRatio).toBeGreaterThanOrEqual(MinAspectRatio);
+            expect(particle.aspectRatio).toBeLessThanOrEqual(MaxAspectRatio);
+            expect(particle.horizontalDrift).toBeGreaterThanOrEqual(MinHorizontalDrift);
+            expect(particle.horizontalDrift).toBeLessThanOrEqual(MaxHorizontalDrift);
+            expect(particle.swayAmplitude).toBeGreaterThanOrEqual(MinSwayAmplitude);
+            expect(particle.swayAmplitude).toBeLessThanOrEqual(MaxSwayAmplitude);
+            expect(Math.abs(particle.spinDegrees)).toBeGreaterThanOrEqual(MinRotationDegrees);
+            expect(Math.abs(particle.spinDegrees)).toBeLessThanOrEqual(MaxRotationDegrees);
+            expect(particle.flipDegrees).toBeGreaterThanOrEqual(MinRotationDegrees);
+            expect(particle.flipDegrees).toBeLessThanOrEqual(MaxRotationDegrees);
+        }
+    });
+
+    it('assigns palette colors only', () => {
+        for (const particle of particles) {
+            expect(winConfettiPaletteConstant).toContain(particle.color);
+        }
+    });
+
+    it('spins particles in both directions', () => {
+        expect(particles.some(particle => particle.spinDegrees > 0)).toBe(true);
+        expect(particles.some(particle => particle.spinDegrees < 0)).toBe(true);
+    });
+
+    it('finishes every particle within the celebration window', () => {
+        for (const particle of particles) {
+            expect(particle.delayMilliseconds + particle.durationMilliseconds).toBeLessThan(winConfettiCelebrationDurationConstant * 1000);
+        }
+    });
+});

--- a/packages/app/src/confetti/utils/create-confetti-particles.util.ts
+++ b/packages/app/src/confetti/utils/create-confetti-particles.util.ts
@@ -1,0 +1,42 @@
+import { winConfettiPaletteConstant } from '../constants/win-confetti.constant';
+
+import type { ConfettiParticleInterface } from '../interfaces/confetti-particle.interface';
+
+const MinSize = 6;
+const MaxSize = 12;
+const MinAspectRatio = 0.4;
+const MaxAspectRatio = 1;
+const MinDurationMilliseconds = 2800;
+const MaxDurationMilliseconds = 4000;
+const MinDelayMilliseconds = 0;
+const MaxDelayMilliseconds = 800;
+const MaxHorizontalDrift = 60;
+const MinSwayAmplitude = 10;
+const MaxSwayAmplitude = 40;
+const MinSpinDegrees = 360;
+const MaxSpinDegrees = 1080;
+const MinFlipDegrees = 360;
+const MaxFlipDegrees = 1080;
+
+const randomInRange = (min: number, max: number): number => min + Math.random() * (max - min);
+
+const randomSign = (): number => (Math.random() < 0.5 ? -1 : 1);
+
+const pickRandomColor = (palette: readonly string[]): string => palette[Math.floor(Math.random() * palette.length)];
+
+const createConfettiParticle = (id: number): ConfettiParticleInterface => ({
+    id,
+    leftRatio: Math.random(),
+    size: randomInRange(MinSize, MaxSize),
+    aspectRatio: randomInRange(MinAspectRatio, MaxAspectRatio),
+    color: pickRandomColor(winConfettiPaletteConstant),
+    durationMilliseconds: randomInRange(MinDurationMilliseconds, MaxDurationMilliseconds),
+    delayMilliseconds: randomInRange(MinDelayMilliseconds, MaxDelayMilliseconds),
+    horizontalDrift: randomInRange(-MaxHorizontalDrift, MaxHorizontalDrift),
+    swayAmplitude: randomInRange(MinSwayAmplitude, MaxSwayAmplitude),
+    spinDegrees: randomSign() * randomInRange(MinSpinDegrees, MaxSpinDegrees),
+    flipDegrees: randomInRange(MinFlipDegrees, MaxFlipDegrees)
+});
+
+export const createConfettiParticles = (amount: number): ConfettiParticleInterface[] =>
+    Array.from({ length: amount }, (_unused, index) => createConfettiParticle(index));

--- a/packages/app/src/confetti/utils/create-confetti-piece-keyframes.util.spec.ts
+++ b/packages/app/src/confetti/utils/create-confetti-piece-keyframes.util.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { createConfettiPieceKeyframes } from './create-confetti-piece-keyframes.util';
+
+import type { ConfettiParticleInterface } from '../interfaces/confetti-particle.interface';
+
+const particle: ConfettiParticleInterface = {
+    aspectRatio: 0.5,
+    color: '#f94144',
+    delayMilliseconds: 100,
+    durationMilliseconds: 3000,
+    flipDegrees: 720,
+    horizontalDrift: 30,
+    id: 0,
+    leftRatio: 0.5,
+    size: 10,
+    spinDegrees: -540,
+    swayAmplitude: 20
+};
+
+describe('createConfettiPieceKeyframes', () => {
+    it('builds the full fall, sway, spin and fade timeline for a particle', () => {
+        expect(createConfettiPieceKeyframes(particle, 800)).toStrictEqual({
+            from: {
+                opacity: 1,
+                transform: [{ translateY: -20 }, { translateX: 0 }, { rotate: '0deg' }, { rotateX: '0deg' }]
+            },
+            '25%': {
+                transform: [{ translateY: 195 }, { translateX: 20 }, { rotate: '-135deg' }, { rotateX: '180deg' }]
+            },
+            '75%': {
+                transform: [{ translateY: 625 }, { translateX: -20 }, { rotate: '-405deg' }, { rotateX: '540deg' }]
+            },
+            '85%': {
+                opacity: 1,
+                transform: [{ translateY: 711 }, { translateX: 0 }, { rotate: '-459deg' }, { rotateX: '612deg' }]
+            },
+            to: {
+                opacity: 0,
+                transform: [{ translateY: 840 }, { translateX: 30 }, { rotate: '-540deg' }, { rotateX: '720deg' }]
+            }
+        });
+    });
+});

--- a/packages/app/src/confetti/utils/create-confetti-piece-keyframes.util.ts
+++ b/packages/app/src/confetti/utils/create-confetti-piece-keyframes.util.ts
@@ -1,0 +1,64 @@
+import type { ConfettiParticleInterface } from '../interfaces/confetti-particle.interface';
+import type { ViewStyle } from 'react-native';
+import type { CSSAnimationKeyframes } from 'react-native-reanimated';
+
+const QuarterProgress = 0.25;
+const ThreeQuarterProgress = 0.75;
+const LateProgress = 0.85;
+const LateHorizontalProgress = 0.4;
+const FallOvershoot = 40;
+
+const interpolateLinear = (from: number, to: number, progress: number): number => from + (to - from) * progress;
+
+export const createConfettiPieceKeyframes = (
+    particle: ConfettiParticleInterface,
+    screenHeight: number
+): CSSAnimationKeyframes<ViewStyle> => {
+    const startTranslateY = -particle.size * 2;
+    const endTranslateY = screenHeight + FallOvershoot;
+    const quarterTranslateY = interpolateLinear(startTranslateY, endTranslateY, QuarterProgress);
+    const threeQuarterTranslateY = interpolateLinear(startTranslateY, endTranslateY, ThreeQuarterProgress);
+    const lateTranslateY = interpolateLinear(startTranslateY, endTranslateY, LateProgress);
+    const lateTranslateX = interpolateLinear(-particle.swayAmplitude, particle.horizontalDrift, LateHorizontalProgress);
+
+    return {
+        from: {
+            opacity: 1,
+            transform: [{ translateY: startTranslateY }, { translateX: 0 }, { rotate: '0deg' }, { rotateX: '0deg' }]
+        },
+        '25%': {
+            transform: [
+                { translateY: quarterTranslateY },
+                { translateX: particle.swayAmplitude },
+                { rotate: `${particle.spinDegrees * QuarterProgress}deg` },
+                { rotateX: `${particle.flipDegrees * QuarterProgress}deg` }
+            ]
+        },
+        '75%': {
+            transform: [
+                { translateY: threeQuarterTranslateY },
+                { translateX: -particle.swayAmplitude },
+                { rotate: `${particle.spinDegrees * ThreeQuarterProgress}deg` },
+                { rotateX: `${particle.flipDegrees * ThreeQuarterProgress}deg` }
+            ]
+        },
+        '85%': {
+            opacity: 1,
+            transform: [
+                { translateY: lateTranslateY },
+                { translateX: lateTranslateX },
+                { rotate: `${particle.spinDegrees * LateProgress}deg` },
+                { rotateX: `${particle.flipDegrees * LateProgress}deg` }
+            ]
+        },
+        to: {
+            opacity: 0,
+            transform: [
+                { translateY: endTranslateY },
+                { translateX: particle.horizontalDrift },
+                { rotate: `${particle.spinDegrees}deg` },
+                { rotateX: `${particle.flipDegrees}deg` }
+            ]
+        }
+    };
+};

--- a/packages/app/src/screens/components/game-screen/game.screen.tsx
+++ b/packages/app/src/screens/components/game-screen/game.screen.tsx
@@ -17,6 +17,7 @@ import { ChallengeRaceHud } from '../../../challenge/components/challenge-race-h
 import { ChallengeRecordHud } from '../../../challenge/components/challenge-record-hud/challenge-record-hud';
 import { ChallengeScreenshotRecorder } from '../../../challenge/components/challenge-screenshot-recorder/challenge-screenshot-recorder';
 import { classifyTimelineMove } from '../../../challenge/utils/classify-timeline-move.util';
+import { WinConfettiContext } from '../../../confetti/context/win-confetti.context';
 import { Field, FieldRef } from '../../../game/components/field/field';
 import { GameTimerController } from '../../../game/components/game-timer-controller/game-timer-controller';
 import { GameContext } from '../../../game/context/game.context';
@@ -55,6 +56,7 @@ import { GameStatusBlock } from './game-status-block/game-status-block';
 import { useOpenGameSettings } from './hooks/use-open-game-settings.hook';
 import { gameScreenExit } from './utils/game-screen-exit.util';
 import { gameScreenGetLostRoute, gameScreenGetWonRoute } from './utils/game-screen-get-result-route.util';
+import { gameScreenMaybeStartWinConfetti } from './utils/game-screen-maybe-start-win-confetti.util';
 
 import type { AvailableValuesItemRef } from '../../../game/components/available-values-item/available-values-item';
 import type { CellInterface, ScoredCellsInterface } from '@suuudokuuu/generator';
@@ -67,6 +69,7 @@ export const GameScreen = () => {
 
     const { sudoku } = use(GameContext);
     const { theme } = use(ThemeContext);
+    const startWinConfetti = use(WinConfettiContext);
 
     const [hapticNotification, hapticImpact] = useVibration();
 
@@ -141,9 +144,8 @@ export const GameScreen = () => {
         hapticImpact(ImpactFeedbackStyle.Heavy);
 
         const wonChallenge = hasRival && elapsedTime < challengeTime;
-
+        gameScreenMaybeStartWinConfetti(hasRival, wonChallenge, startWinConfetti);
         dispatch(gameFinishAction({ difficulty, isWon: true, isChallenge: wonChallenge }));
-
         // HINT: We need to wait for the animation to finish, animation finish event would fix it?
         setTimeout(() => void router.replace(gameScreenGetWonRoute(hasRival, wonChallenge)), 10 * animationDurationConstant);
     };

--- a/packages/app/src/screens/components/game-screen/utils/game-screen-maybe-start-win-confetti.util.spec.ts
+++ b/packages/app/src/screens/components/game-screen/utils/game-screen-maybe-start-win-confetti.util.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { gameScreenMaybeStartWinConfetti } from './game-screen-maybe-start-win-confetti.util';
+
+describe('gameScreenMaybeStartWinConfetti', () => {
+    it('starts the confetti for a solo win', () => {
+        const startWinConfetti = jest.fn();
+
+        gameScreenMaybeStartWinConfetti(false, false, startWinConfetti);
+
+        expect(startWinConfetti).toHaveBeenCalledTimes(1);
+    });
+
+    it('starts the confetti for a won challenge', () => {
+        const startWinConfetti = jest.fn();
+
+        gameScreenMaybeStartWinConfetti(true, true, startWinConfetti);
+
+        expect(startWinConfetti).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips the confetti when the rival was faster', () => {
+        const startWinConfetti = jest.fn();
+
+        gameScreenMaybeStartWinConfetti(true, false, startWinConfetti);
+
+        expect(startWinConfetti).not.toHaveBeenCalled();
+    });
+});

--- a/packages/app/src/screens/components/game-screen/utils/game-screen-maybe-start-win-confetti.util.ts
+++ b/packages/app/src/screens/components/game-screen/utils/game-screen-maybe-start-win-confetti.util.ts
@@ -1,0 +1,7 @@
+export const gameScreenMaybeStartWinConfetti = (hasRival: boolean, wonChallenge: boolean, startWinConfetti: () => void): void => {
+    const isCelebrationWin = !hasRival || wonChallenge;
+
+    if (isCelebrationWin) {
+        startWinConfetti();
+    }
+};


### PR DESCRIPTION
## Summary

Winning confetti for solo wins and won challenges, rendered with Reanimated 4 CSS keyframe animations — no new dependencies, working identically on iOS, Android, and web.

Fixes #68. Supersedes #113.

## Why not typegpu-confetti (the #113 approach)

The upstream blocker from #113 is actually resolved (`typegpu-confetti@0.3.0` now supports `react-native-wgpu >= 0.4.2`), but a fresh ecosystem survey disqualified that path for this app:

- `react-native-wgpu` ships ~163 MB of Dawn binaries with no per-platform split ([react-native-webgpu#304](https://github.com/wcandillon/react-native-webgpu/issues/304)) — a disproportionate binary cost for one celebration effect.
- WebGPU still covers only ~82% of browsers, and `typegpu-confetti` throws instead of no-oping where it is missing ([typegpu-confetti#36](https://github.com/software-mansion-labs/typegpu-confetti/issues/36)).
- `react-native-fast-confetti` v2 (the original #68 suggestion) would pull in Skia plus a ~2.9 MB CanvasKit wasm payload on web, and its web support is undocumented.

The stack already ships the state of the art for this: Reanimated 4 CSS animations compile to UI-thread animations natively and to real GPU-composited CSS keyframes on web, in 100% of browsers, at zero dependency and bundle cost.

## Implementation

- `confetti/` module: `WinConfettiProvider` context wraps the root `Stack`; the 250-piece burst mounts only during the five-second celebration window (zero cost otherwise) and survives the redirect so it keeps falling over the winner screen.
- Each piece is one `Reanimated.View` with per-particle randomized keyframes (fall, sway, spin, flip, fade) — no per-frame JS, no hooks per particle.
- Celebration fires only for `/winner` and `/challenge-won`; completing the board slower than the rival routes to `challenge-lost` and stays celebration-free.
- Drive-by fix: `expo-screen-capture`'s `useScreenshotListener` throws on web and black-screened every challenge run on the game screen; `challenge-screenshot-recorder.web.tsx` now renders nothing on web.

## Validation

- `yarn format && yarn ts && yarn lint && yarn deadcode && yarn cpd` — clean.
- `yarn test` — all suites green (705 app, 157 encoder, 70 generator, 99 solver, 35 ui).
- Web runtime: drove the E2E win fixture (`shared/_KGP…`, one empty cell) end to end in a browser — exactly 250 CSS-animated pieces mount at the winning input with the palette colors, the overlay computes `pointer-events: none`, the challenge-won screen renders, and the overlay unmounts after the window closes. Repeated across multiple runs.
- Native builds are exercised by CI/EAS preview; the implementation uses only Reanimated 4 APIs already shipped in the app.
