### PR TITLE
fix(app): target the released version when pushing store metadata

### DIFF
--- a/.github/workflows/native-publish.yml
+++ b/.github/workflows/native-publish.yml
@@ -38,6 +38,7 @@ jobs:
               uses: actions/checkout@v5
               with:
                   ref: main
+                  fetch-depth: 0
 
             - name: Setup Node
               uses: actions/setup-node@v6
@@ -157,6 +158,7 @@ jobs:
               uses: actions/checkout@v5
               with:
                   ref: main
+                  fetch-depth: 0
 
             - name: Setup Node
               uses: actions/setup-node@v6
@@ -239,6 +241,7 @@ jobs:
               uses: actions/checkout@v5
               with:
                   ref: main
+                  fetch-depth: 0
 
             - name: Setup Node
               uses: actions/setup-node@v6
@@ -351,14 +354,14 @@ jobs:
               working-directory: packages/app
               env:
                   GOOGLE_SERVICE_ACCOUNT_KEY_PATH: ${{ github.workspace }}/packages/app/google-service-account.json
-              run: fastlane android_metadata
+              run: fastlane android android_metadata
 
             - name: Push Play Store screenshots
               if: inputs.push_screenshots
               working-directory: packages/app
               env:
                   GOOGLE_SERVICE_ACCOUNT_KEY_PATH: ${{ github.workspace }}/packages/app/google-service-account.json
-              run: fastlane android_screenshots
+              run: fastlane android android_screenshots
 
             - name: Remove Google Play service account key
               if: always()

--- a/packages/app/fastlane/Fastfile
+++ b/packages/app/fastlane/Fastfile
@@ -1,5 +1,13 @@
 default_platform(:ios)
 
+# deliver writes into the editable App Store version, and a freshly uploaded
+# build does not create one on its own. Naming the version explicitly makes
+# deliver select or create it instead of failing with "could not find an
+# editable version".
+def app_version_from_package_json
+  JSON.parse(File.read("./package.json")).fetch("version")
+end
+
 platform :ios do
   lane :ios_metadata do
     app_store_connect_api_key(
@@ -9,6 +17,7 @@ platform :ios do
     )
 
     deliver(
+      app_version: app_version_from_package_json,
       skip_binary_upload: true,
       skip_screenshots: true,
       force: true,
@@ -28,6 +37,7 @@ platform :ios do
     screenshot_variant = ENV.fetch("SCREENSHOT_VARIANT", deployed_variants.fetch("ios"))
 
     deliver(
+      app_version: app_version_from_package_json,
       skip_binary_upload: true,
       skip_metadata: true,
       skip_screenshots: false,


### PR DESCRIPTION
The 1.74.3 publish uploaded the iOS binary successfully but then failed on the metadata step:

```
[!] Cannot update languages - could not find an editable version for 'IOS'
```

`deliver` writes into the editable App Store Connect version, and a freshly uploaded build does not create one by itself. Both `ios_metadata` and `ios_screenshots` now pass `app_version` read from the app package manifest, so deliver selects (or creates) the right version instead of failing.

Verified with `ruby -c` and by resolving the version locally (1.74.3).