### PR TITLE
ci: pin run-maestro-android-redroid to v1.0.0, resolve #253's open questions

### DIFF
--- a/.github/workflows/android-maestro.yml
+++ b/.github/workflows/android-maestro.yml
@@ -32,7 +32,7 @@ jobs:
                   path: .ci-artifacts/android-e2e-app
 
             - name: run-maestro-android-redroid
-              uses: rnw-community/mobile-ci/actions/run-maestro-android-redroid@bc5927455f3ca5aed5c1b7733c9286fc8b53769e # v1.0.0
+              uses: rnw-community/mobile-ci/actions/run-maestro-android-redroid@0eadcb345bc704b1ccc8e9965634af1ff3d2e25e # v1.1.0
               with:
                   container-name: redroid-e2e
                   apk-path: .ci-artifacts/android-e2e-app/suuudokuuu-e2e.apk

--- a/.github/workflows/android-maestro.yml
+++ b/.github/workflows/android-maestro.yml
@@ -32,12 +32,14 @@ jobs:
                   path: .ci-artifacts/android-e2e-app
 
             - name: run-maestro-android-redroid
-              uses: rnw-community/mobile-ci/actions/run-maestro-android-redroid@92b18c6b0d207e46ba13ae7e7546966755d36e9f # main
+              uses: rnw-community/mobile-ci/actions/run-maestro-android-redroid@bc5927455f3ca5aed5c1b7733c9286fc8b53769e # v1.0.0
               with:
                   container-name: redroid-e2e
                   apk-path: .ci-artifacts/android-e2e-app/suuudokuuu-e2e.apk
                   app-id: com.vitaliiyehorov.suuudokuuu.e2e
                   flows-dir: tests/app-tests/flows
+                  pre-run-flow: tests/app-tests/flows/setup/prime-deep-links.flow.yaml
+                  flow-retries: '1'
                   shard-index: '0'
                   shard-count: '1'
                   maestro-version: '2.6.1'


### PR DESCRIPTION
## Context

#253 ("ci: adopt mobile-ci's run-maestro-android-redroid action") merged
already pinned to a pre-`v1` commit SHA
(`92b18c6b0d207e46ba13ae7e7546966755d36e9f # main`), with both of its
"Open question" sections left unresolved and its own "must not merge until
this is resolved" note unaddressed. `rnw-community/mobile-ci` has since
shipped `v1.0.0` (tag `v1` = `v1.0.0` = `bc5927455f3ca5aed5c1b7733c9286fc8b53769e`),
which answers both questions without any repo-layout change. This PR:

1. Re-pins to the `v1.0.0` commit SHA.
2. Wires the two new inputs that restore what #253 flagged as lost.

## Open question 1 (resolved) — `flows-dir` recursion

#253 found that pointing `flows-dir` at `tests/app-tests/flows` picked up 45
`.yaml`/`.yml` files recursively (the pre-`v1` action's `find "$FLOWS_DIR"
-type f \( -name '*.yaml' -o -name '*.yml' \)`, no depth limit), versus the
14 numbered scenario flows the suite actually runs, and did not want to
restructure the flows directory to work around it.

`v1.0.0` changed flow discovery to **top-level-only by default**:
`flows-max-depth` defaults to `1` and `flows-name-pattern` defaults to
`*.flow.yaml`. That is exactly this repo's own convention (documented in
`tests/app-tests/AGENTS.md`: "Keep numbered flows as user scenarios. One-time
native handoff setup belongs in `flows/setup`; reusable app interactions
belong in `flows/subflows`") and exactly what the old hand-rolled workflow
ran (`find flows -maxdepth 1 -type f -name '*.flow.yaml'`). Verified locally:
`find tests/app-tests/flows -maxdepth 1 -type f -name '*.flow.yaml' | wc -l`
→ **14**, matching the pre-migration suite exactly, with `flows-dir` left
unchanged at `tests/app-tests/flows`. No repo-layout change needed — the
`v1.0.0` default already does the right thing.

## Open question 2 (resolved) — lost harness features

#253 flagged that switching off `scripts/run-maestro-suite.sh` for the
Android job dropped the one-time `flows/setup/prime-deep-links.flow.yaml`
priming run and the per-flow retry-on-driver-failure behavior, and noted
there was no replacement for the timing summary.

- **Priming flow**: wired as the new `pre-run-flow` input
  (`tests/app-tests/flows/setup/prime-deep-links.flow.yaml`), run once before
  the shard and excluded from sharding/discovery, matching what
  `run-maestro-suite.sh` did unconditionally on every platform including
  Android.
- **Retry budget**: `flow-retries: '1'` matches the old harness's "retry once
  after a recoverable driver failure" policy (max 2 attempts per flow). The
  old pattern list (`driver-failure-pattern.sh`) was iOS-specific by its own
  comment, so this was already a low-impact no-op on Android; setting
  `flow-retries: '1'` preserves the same attempt budget going forward without
  depending on that iOS-only pattern match.
- **Timing summary**: no action needed — `v1.0.0` now builds a per-flow
  timing table (flow, duration, status, attempts) into
  `$GITHUB_STEP_SUMMARY` automatically, including a priming-flow row when
  `pre-run-flow` is set. This replaces the dropped `flow-timings.tsv` →
  step-summary table from `run-maestro-suite.sh`.

## Preserved from #253

App id (`com.vitaliiyehorov.suuudokuuu.e2e`), prewarm manifest path
(`$HOME/.sudoku-ci/android-emulator.json`), runner labels
(`[self-hosted, linux-tiered, linux-xl]`), `memory`/`cpus`, and all artifact
wiring are unchanged from what #253 landed.

## Verified

- `actionlint .github/workflows/android-maestro.yml` — same two pre-existing
  `runner-label` notices #253 already documented (custom self-hosted labels
  actionlint can't resolve); no new findings.
- `find tests/app-tests/flows -maxdepth 1 -type f -name '*.flow.yaml' | wc -l`
  → 14 (matches pre-migration suite exactly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)