### PR TITLE
ci: migrate github actions to latest major versions

### DIFF
--- a/.github/workflows/android-maestro.yml
+++ b/.github/workflows/android-maestro.yml
@@ -24,9 +24,9 @@ jobs:
         runs-on: [self-hosted, linux-tiered, linux-xl]
         timeout-minutes: 45
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@v7
 
-            - uses: actions/download-artifact@v6
+            - uses: actions/download-artifact@v8
               with:
                   name: android-e2e-app
                   path: .ci-artifacts/android-e2e-app

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,7 +34,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@v7
               with:
                   fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@v7
 
             - name: Initialize CodeQL
               uses: github/codeql-action/init@v4

--- a/.github/workflows/ios-maestro.yml
+++ b/.github/workflows/ios-maestro.yml
@@ -26,7 +26,7 @@ jobs:
                     - shard-index: 1
                       shard-number: 2
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@v7
 
             - name: Select Xcode
               run: |
@@ -67,7 +67,7 @@ jobs:
                   done
                   echo "SIMULATOR_UDID=$simulator_udid" >> "$GITHUB_ENV"
 
-            - uses: actions/download-artifact@v6
+            - uses: actions/download-artifact@v8
               with:
                   name: ios-e2e-app
                   path: .ci-artifacts/ios-e2e-app
@@ -140,7 +140,7 @@ jobs:
                   xcrun simctl io "$SIMULATOR_UDID" screenshot "tests/app-tests/artifacts/simulator-shard-${{ matrix.shard-index }}/final-screen.png" || true
                   xcrun simctl shutdown "$SIMULATOR_UDID" || true
 
-            - uses: actions/upload-artifact@v6
+            - uses: actions/upload-artifact@v7
               if: always()
               with:
                   name: maestro-ios-shard-${{ matrix.shard-number }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,14 +30,14 @@ jobs:
         timeout-minutes: 20
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   ref: main
                   persist-credentials: false
                   fetch-depth: 0
 
             - name: Setup Node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version: 22.x
                   cache: yarn
@@ -93,12 +93,12 @@ jobs:
         timeout-minutes: 20
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
               with:
                   ref: main
 
             - name: Setup Node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v7
               with:
                   node-version: 22.x
                   cache: yarn

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -27,9 +27,9 @@ jobs:
             RCT_USE_RN_DEP: '1'
             IOS_DERIVED_DATA: ${{ github.workspace }}/.ci-cache/DerivedData/suuudokuuu-e2e
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@v7
 
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@v7
               with:
                   node-version: 22.x
                   cache: yarn
@@ -38,7 +38,7 @@ jobs:
               run: yarn install
 
             - name: Setup EAS CLI
-              uses: expo/expo-github-action@v8
+              uses: expo/expo-github-action@v9
               with:
                   eas-version: ${{ env.EAS_CLI_VERSION }}
                   token: ${{ secrets.EXPO_TOKEN }}
@@ -60,7 +60,7 @@ jobs:
 
             - name: Restore fingerprinted native app
               id: native-app-cache
-              uses: actions/cache/restore@v5
+              uses: actions/cache/restore@v6
               with:
                   path: .ci-cache/ios-native-app
                   key: ios-native-v2-macos26-suuudokuuu-e2e-${{ runner.os }}-arm64-xcode26_4_1-17E202-${{ steps.fingerprint.outputs.hash }}
@@ -119,7 +119,7 @@ jobs:
 
             - name: Restore CocoaPods cache
               if: steps.native-plan.outputs.required == 'true'
-              uses: actions/cache/restore@v5
+              uses: actions/cache/restore@v6
               with:
                   path: |
                       ~/Library/Caches/CocoaPods
@@ -177,7 +177,7 @@ jobs:
 
             - name: Save fingerprinted native app
               if: steps.native-app-cache.outputs.cache-hit != 'true'
-              uses: actions/cache/save@v5
+              uses: actions/cache/save@v6
               with:
                   path: .ci-cache/ios-native-app
                   key: ios-native-v2-macos26-suuudokuuu-e2e-${{ runner.os }}-arm64-xcode26_4_1-17E202-${{ steps.fingerprint.outputs.hash }}
@@ -201,7 +201,7 @@ jobs:
                   mkdir -p .ci-artifacts/ios-e2e-app
                   tar -C "$(dirname "$app_path")" -czf ".ci-artifacts/ios-e2e-app/$(basename "$app_path").tar.gz" "$(basename "$app_path")"
 
-            - uses: actions/upload-artifact@v6
+            - uses: actions/upload-artifact@v7
               with:
                   name: ios-e2e-app
                   path: .ci-artifacts/ios-e2e-app/*.tar.gz
@@ -225,9 +225,9 @@ jobs:
             ANDROID_E2E_ABI: arm64-v8a
             ANDROID_E2E_PACKAGE: com.vitaliiyehorov.suuudokuuu.e2e
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@v7
 
-            - uses: actions/setup-node@v6
+            - uses: actions/setup-node@v7
               with:
                   node-version: 22.x
                   cache: yarn
@@ -255,7 +255,7 @@ jobs:
               run: yarn install
 
             - name: Setup EAS CLI
-              uses: expo/expo-github-action@v8
+              uses: expo/expo-github-action@v9
               with:
                   eas-version: ${{ env.EAS_CLI_VERSION }}
                   token: ${{ secrets.EXPO_TOKEN }}
@@ -277,7 +277,7 @@ jobs:
 
             - name: Restore fingerprinted native APK
               id: native-apk-cache
-              uses: actions/cache/restore@v5
+              uses: actions/cache/restore@v6
               with:
                   path: .ci-cache/android-native-apk
                   key: android-native-v1-suuudokuuu-e2e-${{ runner.os }}-${{ env.ANDROID_E2E_ABI }}-${{ steps.fingerprint.outputs.hash }}
@@ -327,7 +327,7 @@ jobs:
 
             - name: Restore Gradle cache
               if: steps.native-plan.outputs.required == 'true'
-              uses: actions/cache@v5
+              uses: actions/cache@v6
               with:
                   path: |
                       ~/.gradle/caches
@@ -356,7 +356,7 @@ jobs:
 
             - name: Save fingerprinted native APK
               if: steps.native-apk-cache.outputs.cache-hit != 'true'
-              uses: actions/cache/save@v5
+              uses: actions/cache/save@v6
               with:
                   path: .ci-cache/android-native-apk
                   key: android-native-v1-suuudokuuu-e2e-${{ runner.os }}-${{ env.ANDROID_E2E_ABI }}-${{ steps.fingerprint.outputs.hash }}
@@ -380,7 +380,7 @@ jobs:
                   mkdir -p .ci-artifacts/android-e2e-app
                   cp "$apk" .ci-artifacts/android-e2e-app/suuudokuuu-e2e.apk
 
-            - uses: actions/upload-artifact@v6
+            - uses: actions/upload-artifact@v7
               with:
                   name: android-e2e-app
                   path: .ci-artifacts/android-e2e-app/*.apk

--- a/.github/workflows/native-dev-build.yml
+++ b/.github/workflows/native-dev-build.yml
@@ -32,7 +32,7 @@ jobs:
             RCT_USE_RN_DEP: '1'
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@v7
               with:
                   ref: ${{ github.sha }}
 
@@ -48,7 +48,7 @@ jobs:
                   fi
 
             - name: Setup Node
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@v7
               with:
                   node-version: 22.x
                   cache: yarn
@@ -95,13 +95,13 @@ jobs:
                   xcodebuild -version
 
             - name: Setup Expo and EAS
-              uses: expo/expo-github-action@v8
+              uses: expo/expo-github-action@v9
               with:
                   eas-version: ${{ env.EAS_CLI_VERSION }}
                   token: ${{ secrets.EXPO_TOKEN }}
 
             - name: ASC API Key file creation
-              uses: MobileDevOps/secret-to-file-action@v1.0.0
+              uses: MobileDevOps/secret-to-file-action@v2.0.0
               with:
                   base64-encoded-secret: ${{ secrets.EXPO_IOS_ASC_API_KEY }}
                   filename: 'packages/app/asc_api_key.p8'
@@ -178,7 +178,7 @@ jobs:
                   NODE
 
             - name: Upload iOS artifact
-              uses: actions/upload-artifact@v6
+              uses: actions/upload-artifact@v7
               with:
                   name: suuudokuuu-development-ios
                   path: |
@@ -197,12 +197,12 @@ jobs:
         timeout-minutes: 120
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@v7
               with:
                   ref: ${{ github.sha }}
 
             - name: Setup Node
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@v7
               with:
                   node-version: 22.x
                   cache: yarn
@@ -238,7 +238,7 @@ jobs:
                   }
 
             - name: Setup Expo and EAS
-              uses: expo/expo-github-action@v8
+              uses: expo/expo-github-action@v9
               with:
                   eas-version: ${{ env.EAS_CLI_VERSION }}
                   token: ${{ secrets.EXPO_TOKEN }}
@@ -253,7 +253,7 @@ jobs:
                   eas build --platform android --profile development --local --non-interactive --output ../../artifacts/suuudokuuu-development.apk
 
             - name: Upload Android artifact
-              uses: actions/upload-artifact@v6
+              uses: actions/upload-artifact@v7
               with:
                   name: suuudokuuu-development-android
                   path: artifacts/suuudokuuu-development.apk
@@ -269,18 +269,18 @@ jobs:
             contents: write
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@v7
               with:
                   ref: ${{ github.sha }}
 
             - name: Download iOS artifact
-              uses: actions/download-artifact@v6
+              uses: actions/download-artifact@v8
               with:
                   name: suuudokuuu-development-ios
                   path: artifacts
 
             - name: Download Android artifact
-              uses: actions/download-artifact@v6
+              uses: actions/download-artifact@v8
               with:
                   name: suuudokuuu-development-android
                   path: artifacts

--- a/.github/workflows/native-publish.yml
+++ b/.github/workflows/native-publish.yml
@@ -35,13 +35,13 @@ jobs:
             RCT_USE_RN_DEP: '1'
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@v7
               with:
                   ref: main
                   fetch-depth: 0
 
             - name: Setup Node
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@v7
               with:
                   node-version: 22.x
                   cache: yarn
@@ -92,13 +92,13 @@ jobs:
                   xcodebuild -version
 
             - name: Setup Expo and EAS
-              uses: expo/expo-github-action@v8
+              uses: expo/expo-github-action@v9
               with:
                   eas-version: ${{ env.EAS_CLI_VERSION }}
                   token: ${{ secrets.EXPO_TOKEN }}
 
             - name: ASC API Key file creation
-              uses: MobileDevOps/secret-to-file-action@v1.0.0
+              uses: MobileDevOps/secret-to-file-action@v2.0.0
               with:
                   base64-encoded-secret: ${{ secrets.EXPO_IOS_ASC_API_KEY }}
                   filename: 'packages/app/asc_api_key.p8'
@@ -117,7 +117,7 @@ jobs:
                   eas build --platform ios --profile production --local --non-interactive --output ../../artifacts/suuudokuuu-production.ipa
 
             - name: Upload iOS artifact
-              uses: actions/upload-artifact@v6
+              uses: actions/upload-artifact@v7
               with:
                   name: suuudokuuu-production-ios
                   path: artifacts/suuudokuuu-production.ipa
@@ -159,13 +159,13 @@ jobs:
         timeout-minutes: 60
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@v7
               with:
                   ref: main
                   fetch-depth: 0
 
             - name: Setup Node
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@v7
               with:
                   node-version: 22.x
                   cache: yarn
@@ -191,7 +191,7 @@ jobs:
               run: ../../node_modules/.bin/expo prebuild --platform android --no-install --clean
 
             - name: Cache Gradle
-              uses: actions/cache@v5
+              uses: actions/cache@v6
               with:
                   path: |
                       ~/.gradle/caches
@@ -226,7 +226,7 @@ jobs:
 
             - name: Upload lint report
               if: failure()
-              uses: actions/upload-artifact@v6
+              uses: actions/upload-artifact@v7
               with:
                   name: suuudokuuu-production-android-lint
                   path: |
@@ -242,13 +242,13 @@ jobs:
         timeout-minutes: 120
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@v7
               with:
                   ref: main
                   fetch-depth: 0
 
             - name: Setup Node
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@v7
               with:
                   node-version: 22.x
                   cache: yarn
@@ -310,13 +310,13 @@ jobs:
                   }
 
             - name: Setup Expo and EAS
-              uses: expo/expo-github-action@v8
+              uses: expo/expo-github-action@v9
               with:
                   eas-version: ${{ env.EAS_CLI_VERSION }}
                   token: ${{ secrets.EXPO_TOKEN }}
 
             - name: Google Play service account file creation
-              uses: MobileDevOps/secret-to-file-action@v1.0.0
+              uses: MobileDevOps/secret-to-file-action@v2.0.0
               with:
                   base64-encoded-secret: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
                   filename: 'packages/app/google-service-account.json'
@@ -343,7 +343,7 @@ jobs:
                   }
 
             - name: Upload Android artifact
-              uses: actions/upload-artifact@v6
+              uses: actions/upload-artifact@v7
               with:
                   name: suuudokuuu-production-android
                   path: artifacts/suuudokuuu-production.aab

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,7 @@ jobs:
             mobile: ${{ steps.mobile.outputs.mobile }}
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@v7
               with:
                   fetch-depth: 0
 
@@ -91,10 +91,10 @@ jobs:
             pull-requests: write
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@v7
 
             - name: Setup Node
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@v7
               with:
                   node-version: 22.x
                   cache: yarn
@@ -126,7 +126,7 @@ jobs:
               run: yarn test:coverage
 
             - name: Upload coverage reports to Codecov
-              uses: codecov/codecov-action@v5
+              uses: codecov/codecov-action@v7
 
     mobile-e2e:
         if: ${{ needs.changes.outputs.mobile == 'true' && needs.code-quality.result == 'success' }}

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -22,10 +22,10 @@ jobs:
         timeout-minutes: 20
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v5
+              uses: actions/checkout@v7
 
             - name: Setup Node
-              uses: actions/setup-node@v6
+              uses: actions/setup-node@v7
               with:
                   node-version: 22.x
                   cache: yarn
@@ -46,7 +46,7 @@ jobs:
                   echo "version=$version" >> "$GITHUB_OUTPUT"
 
             - name: Cache Playwright browsers
-              uses: actions/cache@v5
+              uses: actions/cache@v6
               with:
                   path: ~/.cache/ms-playwright
                   key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
@@ -59,7 +59,7 @@ jobs:
 
             - name: Upload Playwright report
               if: failure()
-              uses: actions/upload-artifact@v6
+              uses: actions/upload-artifact@v7
               with:
                   name: playwright-report
                   path: |


### PR DESCRIPTION
## Changes

Bumps every first-party and third-party action to its latest major, eliminating the Node 20 runner deprecation warnings appearing in every job:

| Action | Old | New |
|---|---|---|
| `actions/checkout` | v4 / v5 | v7 |
| `actions/setup-node` | v4 / v6 | v7 |
| `actions/cache` (+ `restore`/`save`) | v5 | v6 |
| `actions/upload-artifact` | v6 | v7 |
| `actions/download-artifact` | v6 | v8 |
| `codecov/codecov-action` | v5 | v7 |
| `expo/expo-github-action` | v8 | v9 |
| `MobileDevOps/secret-to-file-action` | v1.0.0 | v2.0.0 |

Already latest and unchanged: `setup-java@v5`, `setup-android@v4`, `claude-code-action@v1`, `codeql-action@v4`, and the SHA-pinned `rnw-community/mobile-ci` Redroid action.

## Breaking-change review (release notes checked per major crossed)

- **checkout v6** hardened `pull_request_target`/`workflow_run` checkout defaults - no workflow here uses those triggers.
- **setup-node v6/v7** limited automatic caching to npm - every call site already sets `cache: yarn` explicitly.
- **download-artifact v8** turns digest mismatches from warnings into errors by default; upload-artifact v7 (zipped default) remains fully compatible with download-artifact v8 for the cross-job artifact flow (mobile-build uploads, Maestro jobs download). If a digest-mismatch error ever appears, `digest-mismatch: warn` restores the old behavior.
- **secret-to-file v2** keeps the same inputs, adds strict base64/path validation - all three call sites use plain relative filenames, unaffected.
- **expo-github-action v9**, **cache v6**, **upload-artifact v7**, **codecov v6/v7** - Node 24/ESM runtime bumps only, no input changes relevant here.

## Validation

- All 12 workflow files parse (`yaml.safe_load`).
- `actionlint` reports only pre-existing self-hosted runner-label warnings, none related to this diff.
- Diff is exactly 60 `uses:` lines swapped across 11 files, nothing else.